### PR TITLE
Adds an example and avoid a bug on the compiler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 # Ignore the example binaries
 examples/simple
 examples/visualWidth
+example/splitGraphemes
 
 # Ignore the generated files
 generated-docs

--- a/examples/splitGraphemes.roc
+++ b/examples/splitGraphemes.roc
@@ -1,0 +1,20 @@
+app [main] {
+    pf: platform "https://github.com/roc-lang/basic-cli/releases/download/0.11.0/SY4WWMhWQ9NvQgvIthcv15AUeA7rAIJHAHgiaSHGhdY.tar.br",
+    unicode: "../package/main.roc", # use release URL (ends in tar.br) for local example, see github.com/roc/unicode/releases
+}
+
+import pf.Stdout
+import pf.Task
+import unicode.Grapheme
+
+string = "🇦🇺🦘🪃"
+
+expect Grapheme.split string == Ok ["🇦🇺", "🦘", "🪃"]
+
+main =
+    string
+    |> Grapheme.split
+    |> Inspect.toStr
+    |> \splitted ->
+        Stdout.line! "\n\nThe string \"$(string)\" has following graphemes:"
+        Stdout.line! splitted

--- a/package/CodePoint.roc
+++ b/package/CodePoint.roc
@@ -121,8 +121,7 @@ appendUtf8 = \bytes, codePoint ->
     else
         ## This was an invalid Unicode scalar value, even though it had the Roc type Scalar.
         ## This should never happen!
-        expect
-            u32 < 0x110000
+        # expect u32 < 0x110000
 
         byte1 =
             u32
@@ -179,9 +178,7 @@ countUtf8Bytes = \codePoint ->
         3
     else
         # If this expectation fails, it was an invalid Scalar and shouldn't have been allowed!
-        expect
-            u32 < 0x110000
-
+        # expect u32 < 0x110000
         4
 
 ## parse a 2-byte code point

--- a/package/GraphemeTestGen.roc
+++ b/package/GraphemeTestGen.roc
@@ -4,7 +4,7 @@
 ## parse it and then generate the individual tests.
 app [main] {
     pf: platform "https://github.com/roc-lang/basic-cli/releases/download/0.11.0/SY4WWMhWQ9NvQgvIthcv15AUeA7rAIJHAHgiaSHGhdY.tar.br",
-    parser: "https://github.com/lukewilliamboswell/roc-parser/releases/download/0.5.2/9VrPjwfQQ1QeSL3CfmWr2Pr9DESdDIXy97pwpuq84Ck.tar.br",
+    parser: "https://github.com/lukewilliamboswell/roc-parser/releases/download/0.7.1/MvLlME9RxOBjl0QCxyn3LIaoG9pSlaNxCa-t3BfbPNc.tar.br",
 }
 
 import pf.Task exposing [Task]


### PR DESCRIPTION
These commits avoid the bug described at https://github.com/roc-lang/roc/issues/5680.

This is not a bug in the unicode package, but on the compiler. This small fix just side step the problem.

It also adds a short example of the text segmentation function on the module grapheme.