### PR TITLE
Enable default is_eq implementation in CodePoint

### DIFF
--- a/.github/workflows/generate-docs.yaml
+++ b/.github/workflows/generate-docs.yaml
@@ -12,7 +12,7 @@ permissions: {}
 jobs:
   generate-docs:
     name: Generate docs
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     permissions:
       pages: write
       id-token: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ permissions: {}
 jobs:
   build-bundle:
     name: Build package bundle
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     outputs:
       bundle_filename: ${{ steps.bundle.outputs.bundle_filename }}
     defaults:
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install Zig
         uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # 2.2.1
@@ -64,7 +64,7 @@ jobs:
           echo "bundle_filename=$bundle_filename" >> "$GITHUB_OUTPUT"
 
       - name: Upload package bundle artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: package-bundle
           path: dist/${{ steps.bundle.outputs.bundle_filename }}
@@ -78,16 +78,17 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-latest
-          - macos-latest
-          - windows-latest
+          - ubuntu-26.04
+          - ubuntu-26.04-arm
+          - macos-26
+          - windows-2025
     defaults:
       run:
         shell: bash
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install Zig
         uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # 2.2.1
@@ -102,7 +103,7 @@ jobs:
           version: nightly-new-compiler
 
       - name: Download package bundle artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: package-bundle
           path: dist
@@ -115,7 +116,7 @@ jobs:
     needs:
       - build-bundle
       - test-bundle
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     if: github.event_name == 'workflow_dispatch'
     permissions:
       contents: write
@@ -125,10 +126,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Download package bundle artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: package-bundle
           path: dist

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,6 +1,9 @@
 on: 
   pull_request:
   workflow_dispatch:
+  schedule:
+    # Run daily at 11 AM UTC, after the nightlies are typically published.
+     - cron: '0 11 * * *'
 
 # this cancels workflows currently in progress if you start a new one
 concurrency:
@@ -12,25 +15,25 @@ permissions: {}
 
 jobs:
   test-examples:
-    name: Test examples (${{ matrix.os }})
+    name: ./ci/all_tests.sh (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-latest
-          - macos-latest
-          - windows-latest
+          - ubuntu-26.04
+          - ubuntu-26.04-arm
+          - macos-26
+          - windows-2025
     defaults:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
     
       - uses: roc-lang/setup-roc@cbe782d6f165b89c87d99f50a59ac4f5f73b4427
         with:
           version: nightly-new-compiler
-          nightly-tag: nightly-2026-July-03-c562054
 
       - run: roc version
 

--- a/package/CodePoint.roc
+++ b/package/CodePoint.roc
@@ -274,6 +274,9 @@ CodePoint :: { cp : U32 }.{
             crash "Unreachable: the u32 is known to be a valid codepoint."
         }
     }
+
+    # Use default is_eq implementation
+    is_eq : _
 }
 
 # private methods

--- a/package/CodePoint.roc
+++ b/package/CodePoint.roc
@@ -69,7 +69,7 @@ CodePoint :: { cp : U32 }.{
         } else if u32 < 0x800 {
             byte1 =
                 u32
-                    .shift_right_by(6)
+                    .shr_wrap(6)
                     .bitwise_or(0b11000000)
                     .to_u8_wrap()
 
@@ -86,13 +86,13 @@ CodePoint :: { cp : U32 }.{
         } else if u32 < 0x10000 {
             byte1 =
                 u32
-                    .shift_right_by(12)
+                    .shr_wrap(12)
                     .bitwise_or(0b11100000)
                     .to_u8_wrap()
 
             byte2 =
                 u32
-                    .shift_right_by(6)
+                    .shr_wrap(6)
                     .bitwise_and(0b111111)
                     .bitwise_or(0b10000000)
                     .to_u8_wrap()
@@ -112,20 +112,20 @@ CodePoint :: { cp : U32 }.{
 
             byte1 =
                 u32
-                    .shift_right_by(18)
+                    .shr_wrap(18)
                     .bitwise_or(0b11110000)
                     .to_u8_wrap()
 
             byte2 =
                 u32
-                    .shift_right_by(12)
+                    .shr_wrap(12)
                     .bitwise_and(0b111111)
                     .bitwise_or(0b10000000)
                     .to_u8_wrap()
 
             byte3 =
                 u32
-                    .shift_right_by(6)
+                    .shr_wrap(6)
                     .bitwise_and(0b111111)
                     .bitwise_or(0b10000000)
                     .to_u8_wrap()
@@ -288,7 +288,7 @@ is_continuation_byte = |byte| {
 add_continuation : U32, U8 -> U32
 add_continuation = |original, continuation_byte| {
     original
-        .shift_left_by(6)
+        .shl_wrap(6)
         .bitwise_or(U8.bitwise_and(continuation_byte, 0b00111111).to_u32())
 }
 

--- a/package/Scalar.roc
+++ b/package/Scalar.roc
@@ -81,7 +81,7 @@ Scalar :: { cp : CodePoint }.{
     ## `Str.starts_with_scalar('👩‍👩‍👦‍👦')` would be a compiler error because 👩‍👩‍👦‍👦 takes up
     ## multiple code points and cannot be represented as a single [U32].
     ## You'd need to use `Str.starts_with_scalar("🕊")` instead.
-    starts_with_scalar : Str, U32 -> Bool
+    #starts_with_scalar : Str, U32 -> Bool
 
     ## Returns a [List] of the [Unicode scalar values](https://unicode.org/glossary/#unicode_scalar_value)
     ## in the given string.
@@ -97,7 +97,7 @@ Scalar :: { cp : CodePoint }.{
     ## expect Str.to_scalars("I ♥ Roc") == [73, 32, 9829, 32, 82, 111, 99]
     ## expect Str.to_scalars("") == []
     ## ```
-    to_scalars : Str -> List(U32)
+    #to_scalars : Str -> List(U32)
 
     ## Append a [U32] scalar to the given string. If the given scalar is not a valid
     ## unicode value, it returns [Err(InvalidScalar)].
@@ -121,15 +121,15 @@ Scalar :: { cp : CodePoint }.{
     ## f = |state, scalar| List.append state scalar
     ## expect Str.fold_scalars "ABC" [] f == [65, 66, 67]
     ## ```
-    fold_scalars : Str, state, (state, U32 -> state) -> state
-    fold_scalars = |string, init, step| {
-        fold_scalars_help(string, init, step, 0, Str.count_utf8_bytes(string))
-    }
+    # fold_scalars : Str, state, (state, U32 -> state) -> state
+    # fold_scalars = |string, init, step| {
+    #     fold_scalars_help(string, init, step, 0, Str.count_utf8_bytes(string))
+    # }
 
-    fold_scalars_until : Str, state, (state, U32 -> [Break(state), Continue(state)]) -> state
-    fold_scalars_until = |string, init, step| {
-        fold_scalars_until_help(string, init, step, 0, Str.count_utf8_bytes(string))
-    }
+    # fold_scalars_until : Str, state, (state, U32 -> [Break(state), Continue(state)]) -> state
+    # fold_scalars_until = |string, init, step| {
+    #     fold_scalars_until_help(string, init, step, 0, Str.count_utf8_bytes(string))
+    # }
 }
 
 # private methods
@@ -138,19 +138,19 @@ append_scalar_unsafe = |_string, _scalar| {
     crash "TODO"
 }
 
-get_scalar_unsafe : Str, U64 -> { scalar : U32, bytes_parsed : U64 }
+# get_scalar_unsafe : Str, U64 -> { scalar : U32, bytes_parsed : U64 }
 
-fold_scalars_help : Str, state, (state, U32 -> state), U64, U64 -> state
-fold_scalars_help = |string, state, step, index, length| {
-    if index < length {
-        { scalar, bytes_parsed } = get_scalar_unsafe(string, index)
-        new_state = step(state, scalar)
+# fold_scalars_help : Str, state, (state, U32 -> state), U64, U64 -> state
+# fold_scalars_help = |string, state, step, index, length| {
+#     if index < length {
+#         { scalar, bytes_parsed } = get_scalar_unsafe(string, index)
+#         new_state = step(state, scalar)
 
-        fold_scalars_help(string, new_state, step, (index + bytes_parsed), length)
-    } else {
-        state
-    }
-}
+#         fold_scalars_help(string, new_state, step, (index + bytes_parsed), length)
+#     } else {
+#         state
+#     }
+# }
 
 ## Folds over the unicode [U32] values for the given [Str] and calls a function
 ## to update state for each.
@@ -166,19 +166,19 @@ fold_scalars_help = |string, state, step, index, length| {
 ## expect Str.fold_scalars_until("ABC", [], f) == [66]
 ## expect Str.fold_scalars_until("AxC", [], f) == [65, 120, 67]
 ## ```
-fold_scalars_until_help : Str, state, (state, U32 -> [Break(state), Continue(state)]), U64, U64 -> state
-fold_scalars_until_help = |string, state, step, index, length| {
-    if index < length {
-        { scalar, bytes_parsed } = get_scalar_unsafe(string, index)
+# fold_scalars_until_help : Str, state, (state, U32 -> [Break(state), Continue(state)]), U64, U64 -> state
+# fold_scalars_until_help = |string, state, step, index, length| {
+#     if index < length {
+#         { scalar, bytes_parsed } = get_scalar_unsafe(string, index)
 
-        match step(state, scalar) {
-            Continue(new_state) =>
-                fold_scalars_until_help(string, new_state, step, (index + bytes_parsed), length)
+#         match step(state, scalar) {
+#             Continue(new_state) =>
+#                 fold_scalars_until_help(string, new_state, step, (index + bytes_parsed), length)
 
-            Break(new_state) =>
-                new_state
-            }
-    } else {
-        state
-    }
-}
+#             Break(new_state) =>
+#                 new_state
+#             }
+#     } else {
+#         state
+#     }
+# }


### PR DESCRIPTION
A recent compiler change broke this package because `CodePoint` no longer has a default `is_eq` implementation. This PR explicitely adds it back using `is_eq : _`.