### PR TITLE
Update Roc nightly and platform template

### DIFF
--- a/.github/workflows/generate-docs.yaml
+++ b/.github/workflows/generate-docs.yaml
@@ -19,11 +19,14 @@ jobs:
     steps:
       - name: Check out the repository
         uses: actions/checkout@v4
+
+      - name: Read pinned Roc version
+        run: printf 'ROC_NIGHTLY_TAG=%s\n' "$(sed -n '1p' .roc-version)" >> "$GITHUB_ENV"
       
-      - uses: roc-lang/setup-roc@bd311e2fb815a3d2255f7ee14a922f0b736e020b
+      - uses: roc-lang/setup-roc@cbe782d6f165b89c87d99f50a59ac4f5f73b4427
         with:
-          # Note: nightly hashes are not verified because they are updated regularly.
           version: nightly-new-compiler
+          nightly-tag: ${{ env.ROC_NIGHTLY_TAG }}
 
       - run: roc version
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,11 +39,14 @@ jobs:
           version: ${{ env.ZIG_VERSION }}
           use-cache: false
 
+      - name: Read pinned Roc version
+        run: printf 'ROC_NIGHTLY_TAG=%s\n' "$(sed -n '1p' .roc-version)" >> "$GITHUB_ENV"
+
       - name: Install Roc
-        uses: roc-lang/setup-roc@bd311e2fb815a3d2255f7ee14a922f0b736e020b
+        uses: roc-lang/setup-roc@cbe782d6f165b89c87d99f50a59ac4f5f73b4427
         with:
-          # Installs the latest nightly from https://github.com/roc-lang/nightlies
           version: nightly-new-compiler
+          nightly-tag: ${{ env.ROC_NIGHTLY_TAG }}
 
       - name: Run checks
         run: ROC=roc ./ci/all_tests.sh
@@ -96,11 +99,14 @@ jobs:
           version: ${{ env.ZIG_VERSION }}
           use-cache: false
 
+      - name: Read pinned Roc version
+        run: printf 'ROC_NIGHTLY_TAG=%s\n' "$(sed -n '1p' .roc-version)" >> "$GITHUB_ENV"
+
       - name: Install Roc
-        uses: roc-lang/setup-roc@bd311e2fb815a3d2255f7ee14a922f0b736e020b
+        uses: roc-lang/setup-roc@cbe782d6f165b89c87d99f50a59ac4f5f73b4427
         with:
-          # Installs the latest nightly from https://github.com/roc-lang/nightlies
           version: nightly-new-compiler
+          nightly-tag: ${{ env.ROC_NIGHTLY_TAG }}
 
       - name: Download package bundle artifact
         uses: actions/download-artifact@v8
@@ -134,11 +140,14 @@ jobs:
           name: package-bundle
           path: dist
 
+      - name: Read pinned Roc version
+        run: printf 'ROC_NIGHTLY_TAG=%s\n' "$(sed -n '1p' .roc-version)" >> "$GITHUB_ENV"
+
       - name: Install Roc
-        uses: roc-lang/setup-roc@bd311e2fb815a3d2255f7ee14a922f0b736e020b
+        uses: roc-lang/setup-roc@cbe782d6f165b89c87d99f50a59ac4f5f73b4427
         with:
-          # Installs the latest nightly from https://github.com/roc-lang/nightlies
           version: nightly-new-compiler
+          nightly-tag: ${{ env.ROC_NIGHTLY_TAG }}
 
       - name: Create release
         env:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -30,10 +30,14 @@ jobs:
         shell: bash
     steps:
       - uses: actions/checkout@v7
+
+      - name: Read pinned Roc version
+        run: printf 'ROC_NIGHTLY_TAG=%s\n' "$(sed -n '1p' .roc-version)" >> "$GITHUB_ENV"
     
       - uses: roc-lang/setup-roc@cbe782d6f165b89c87d99f50a59ac4f5f73b4427
         with:
           version: nightly-new-compiler
+          nightly-tag: ${{ env.ROC_NIGHTLY_TAG }}
 
       - run: roc version
 

--- a/.roc-version
+++ b/.roc-version
@@ -1,0 +1,1 @@
+nightly-2026-August-04-1cb06bc

--- a/examples/get-visual-width.roc
+++ b/examples/get-visual-width.roc
@@ -1,5 +1,5 @@
 app [main!] {
-    pf: platform "https://github.com/lukewilliamboswell/roc-platform-template-zig/releases/download/0.9/8GdFEvQYS3TeAZxKvTzCLVdQiomweGtXcdZkXNDEeABq.tar.zst",
+    pf: platform "https://github.com/lukewilliamboswell/roc-platform-template-zig/releases/download/1.1.0/ABFgWwu8SwPJfp7tzxDoTL41b1jFeHEac3RxUFSt1WWp.tar.zst",
     unicode: "../package/main.roc", # use release URL (ends in tar.br) for local example, see github.com/roc/unicode/releases
 }
 
@@ -27,7 +27,7 @@ main! = |args| {
     }
     match get_visual_width(word) {
         Ok(width) => {
-            Stdout.line!("\n\nThe word ${word} will be displayed with the width of ${width.to_str()} characters on most UIs.\n\n")
+            Stdout.line!("\n\nThe word ${word} will be displayed with the width of ${width.to_str()} characters on most UIs.\n\n")?
             Ok({})
         }
         Err(_) => {

--- a/examples/nr-of-code-points.roc
+++ b/examples/nr-of-code-points.roc
@@ -1,5 +1,5 @@
 app [main!] {
-    pf: platform "https://github.com/lukewilliamboswell/roc-platform-template-zig/releases/download/0.9/8GdFEvQYS3TeAZxKvTzCLVdQiomweGtXcdZkXNDEeABq.tar.zst",
+    pf: platform "https://github.com/lukewilliamboswell/roc-platform-template-zig/releases/download/1.1.0/ABFgWwu8SwPJfp7tzxDoTL41b1jFeHEac3RxUFSt1WWp.tar.zst",
     unicode: "../package/main.roc", # use release URL (ends in tar.br) for local example, see github.com/roc/unicode/releases
 }
 
@@ -18,12 +18,12 @@ main! = |_args| {
 
     match nr_of_code_points(word) {
         Ok(nr) => {
-            Stdout.line!("String \"${word}\" consists of ${nr.to_str()} code points.")
+            Stdout.line!("String \"${word}\" consists of ${nr.to_str()} code points.")?
             Ok({})
         }
 
         Err(_) => {
-            Stderr.line!("Failed to parse string ${word} as Utf8.")
+            Stderr.line!("Failed to parse string ${word} as Utf8.")?
             Err(Exit(1))
         }
     }

--- a/examples/split-graphemes.roc
+++ b/examples/split-graphemes.roc
@@ -1,5 +1,5 @@
 app [main!] {
-    pf: platform "https://github.com/lukewilliamboswell/roc-platform-template-zig/releases/download/0.9/8GdFEvQYS3TeAZxKvTzCLVdQiomweGtXcdZkXNDEeABq.tar.zst",
+    pf: platform "https://github.com/lukewilliamboswell/roc-platform-template-zig/releases/download/1.1.0/ABFgWwu8SwPJfp7tzxDoTL41b1jFeHEac3RxUFSt1WWp.tar.zst",
     unicode: "../package/main.roc", # use release URL (ends in tar.br) for local example, see github.com/roc/unicode/releases
 }
 
@@ -19,12 +19,12 @@ main! = |args| {
     }
     match Grapheme.split(string) {
         Ok(splitted) => {
-            Stdout.line!("\n\nThe string \"${string}\" has following graphemes:")
-            Stdout.line!(Str.inspect(splitted))
+            Stdout.line!("\n\nThe string \"${string}\" has following graphemes:")?
+            Stdout.line!(Str.inspect(splitted))?
             Ok({})
         }
         Err(_) => {
-            Stderr.line!("Error splitting the string.")
+            Stderr.line!("Error splitting the string.")?
             Err(Exit(1))
         }
     }

--- a/package/GraphemeTestGen.roc
+++ b/package/GraphemeTestGen.roc
@@ -3,7 +3,7 @@
 ## This file will read the test data from `data/GraphemeBreakTest-15.1.0.txt`
 ## parse it and then generate the individual tests.
 app [main!] {
-    pf: platform "https://github.com/lukewilliamboswell/roc-platform-template-zig/releases/download/0.9/8GdFEvQYS3TeAZxKvTzCLVdQiomweGtXcdZkXNDEeABq.tar.zst",
+    pf: platform "https://github.com/lukewilliamboswell/roc-platform-template-zig/releases/download/1.1.0/ABFgWwu8SwPJfp7tzxDoTL41b1jFeHEac3RxUFSt1WWp.tar.zst",
 }
 
 import pf.Stdout
@@ -16,7 +16,7 @@ Rule : [GB1, GB2, GB3, GB4, GB5, GB6, GB7, GB8, GB9, GB9a, GB9b, GB9c, GB11, GB1
 TestTokens : List([BR(Rule), NB(Rule), CP(CodePoint)])
 
 main! = |_args| {
-    Stdout.line!(template)
+    Stdout.line!(template)?
     Ok({})
 }
 

--- a/package/InternalEAWGen.roc
+++ b/package/InternalEAWGen.roc
@@ -3,7 +3,7 @@
 ## This file will read the test data from `data/EastAsianWidth-15.1.0.txt`
 ## parse it and then generate function to test the East Asian Width property of a code point.
 app [main!] {
-    pf: platform "https://github.com/lukewilliamboswell/roc-platform-template-zig/releases/download/0.9/8GdFEvQYS3TeAZxKvTzCLVdQiomweGtXcdZkXNDEeABq.tar.zst",
+    pf: platform "https://github.com/lukewilliamboswell/roc-platform-template-zig/releases/download/1.1.0/ABFgWwu8SwPJfp7tzxDoTL41b1jFeHEac3RxUFSt1WWp.tar.zst",
 }
 
 EawRange : { eawp : Str, start : Str, end : Str }
@@ -13,7 +13,7 @@ import "data/EastAsianWidth-15.1.0.txt" as file : Str
 import Helpers
 
 main! = |_args| {
-    Stdout.line!(template)
+    Stdout.line!(template)?
     Ok({})
 }
 

--- a/package/InternalEmojiGen.roc
+++ b/package/InternalEmojiGen.roc
@@ -3,7 +3,7 @@
 ## This file will read the test data from `data/emoji-data.txt`
 ## parse it and then generate the implementation for each of the Emoji properties.
 app [main!] {
-    pf: platform "https://github.com/lukewilliamboswell/roc-platform-template-zig/releases/download/0.9/8GdFEvQYS3TeAZxKvTzCLVdQiomweGtXcdZkXNDEeABq.tar.zst",
+    pf: platform "https://github.com/lukewilliamboswell/roc-platform-template-zig/releases/download/1.1.0/ABFgWwu8SwPJfp7tzxDoTL41b1jFeHEac3RxUFSt1WWp.tar.zst",
 }
 
 import pf.Stdout
@@ -11,7 +11,7 @@ import "data/emoji-data.txt" as file : Str
 import Helpers exposing [CPMeta, PropertyMap]
 
 main! = |_args| {
-    Stdout.line!(template)
+    Stdout.line!(template)?
     Ok({})
 }
 

--- a/package/InternalGBPGen.roc
+++ b/package/InternalGBPGen.roc
@@ -3,7 +3,7 @@
 ## This file will read the test data from `data/GraphemeBreakProperty-15.1.0.txt`
 ## parse it and then generate the implementation for each of the GBP properties.
 app [main!] {
-    pf: platform "https://github.com/lukewilliamboswell/roc-platform-template-zig/releases/download/0.9/8GdFEvQYS3TeAZxKvTzCLVdQiomweGtXcdZkXNDEeABq.tar.zst",
+    pf: platform "https://github.com/lukewilliamboswell/roc-platform-template-zig/releases/download/1.1.0/ABFgWwu8SwPJfp7tzxDoTL41b1jFeHEac3RxUFSt1WWp.tar.zst",
 }
 
 import pf.Stdout
@@ -11,7 +11,7 @@ import "data/GraphemeBreakProperty-15.1.0.txt" as file : Str
 import Helpers exposing [CPMeta, PropertyMap]
 
 main! = |_args| {
-    Stdout.line!(template)
+    Stdout.line!(template)?
     Ok({})
 }
 


### PR DESCRIPTION
## Summary

- pin Roc to nightly-2026-August-04-1cb06bc through .roc-version
- update platform-template-zig references to release 1.1.0
- upgrade setup-roc to its pinned v0.3.0 commit and have every workflow consume the shared nightly pin
- propagate Stdout and Stderr errors required by the updated platform

## Testing

- ROC=<pinned nightly> ./ci/all_tests.sh
- PATH=<pinned nightly> ROC=<pinned nightly> python3 ci/test_bundle_examples.py
- parsed all workflow YAML with PyYAML
- git diff --check