### PR TITLE
Expand grapheme benchmark with Unicode 17 baselines

### DIFF
--- a/benchmarks/grapheme/README.md
+++ b/benchmarks/grapheme/README.md
@@ -1,11 +1,23 @@
 # Grapheme segmentation benchmark
 
 This local benchmark compares allocation-free extended-grapheme-cluster
-counting over identical UTF-8 bytes:
+counting over identical UTF-8 bytes. It uses a representative set of optimized
+Unicode 17 implementations with iterator or next-boundary APIs, so the timed
+loop does not need to materialize every boundary:
 
 - Roc: `Grapheme.Cursor.push`/`finish`, using this package's Unicode 17 tables.
-- Rust: `unicode-segmentation` 1.13.3, Unicode 17.
-- Go: `clipperhouse/uax29` 2.7.0, Unicode 17.
+- Rust/ICU4X: `icu_segmenter` 2.2.0, Unicode 17, from the Unicode Consortium.
+- Go: `clipperhouse/uax29` 2.7.0, Unicode 17, with a specialized forward
+  iterator.
+- C: `libgrapheme` 3.0.0, Unicode 17, with its UTF-8 next-break API.
+- Rust/reference: `unicode-segmentation` 1.13.3, Unicode 17. This is a popular
+  general-purpose, forward/reverse, partial-chunk cursor rather than the Rust
+  throughput frontier.
+
+These are implementation comparisons, not language comparisons. In
+particular, the two Rust libraries deliberately show how much library and API
+design can matter within one language. The set is a practical performance
+frontier, not a claim to exhaust every Unicode implementation.
 
 The runner generates ASCII, combining-mark, multilingual, emoji, and official
 Unicode conformance corpora. It builds optimized binaries, calibrates each
@@ -19,9 +31,13 @@ default when `taskset` is available.
 - Roc and Zig
 - Rust/Cargo
 - Go
+- A C compiler supporting `-flto`, and POSIX `make`
+- Network access on the first build
 
 Rust and Go library versions are locked in `Cargo.lock` and `go.sum`. Override
 tool locations with command-line options or set `ROC` for the Roc compiler.
+The runner downloads the pinned `libgrapheme` 3.0.0 source archive into the
+ignored build directory and verifies its SHA-256 before building it.
 
 From the repository root:
 
@@ -65,6 +81,9 @@ the segmentation core rather than allocation and reference-count behavior from
 materializing lists of ranges or strings. Input reading, process startup, and
 printing one checksum are included but amortized over repeated scans.
 
-Every implementation must produce the same cluster count on every corpus, and
-the conformance corpus must match the Unicode 17 expected count. The runner
-aborts rather than reporting incomparable timings when those checks fail.
+Before timing, every implementation emits a compact signature of all boundary
+positions. The signatures must agree on every corpus, and the official corpus
+must match the boundaries encoded in Unicode 17's `GraphemeBreakTest.txt`.
+This catches misplaced boundaries even when the total cluster count happens to
+match. The runner aborts rather than reporting incomparable timings when those
+checks fail.

--- a/benchmarks/grapheme/c/main.c
+++ b/benchmarks/grapheme/c/main.c
@@ -1,0 +1,102 @@
+#include <inttypes.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include <grapheme.h>
+
+static unsigned char *
+read_source(size_t *source_len, uint64_t *repeats)
+{
+	unsigned char header[9];
+	unsigned char *source = NULL;
+	size_t capacity = 0;
+
+	if (fread(header, 1, sizeof(header), stdin) != sizeof(header) ||
+	    header[8] != '\n') {
+		fputs("expected 8-digit repeat count, newline, and UTF-8 corpus\n",
+		      stderr);
+		exit(1);
+	}
+	*repeats = 0;
+	for (size_t i = 0; i < 8; i++) {
+		if (header[i] < '0' || header[i] > '9') {
+			fputs("invalid repeat count\n", stderr);
+			exit(1);
+		}
+		*repeats = *repeats * 10 + (uint64_t)(header[i] - '0');
+	}
+
+	*source_len = 0;
+	for (;;) {
+		if (*source_len == capacity) {
+			capacity = capacity == 0 ? 4096 : capacity * 2;
+			unsigned char *grown = realloc(source, capacity);
+			if (grown == NULL) {
+				perror("realloc");
+				free(source);
+				exit(1);
+			}
+			source = grown;
+		}
+		size_t read = fread(source + *source_len, 1,
+		                    capacity - *source_len, stdin);
+		*source_len += read;
+		if (read == 0) {
+			if (ferror(stdin)) {
+				perror("fread");
+				free(source);
+				exit(1);
+			}
+			break;
+		}
+	}
+	return source;
+}
+
+static size_t
+next_break(const unsigned char *source, size_t source_len, size_t offset)
+{
+	size_t width = grapheme_next_character_break_utf8(
+		(const char *)source + offset, source_len - offset);
+	if (width == 0 || width > source_len - offset) {
+		fputs("libgrapheme returned an invalid break offset\n", stderr);
+		exit(1);
+	}
+	return width;
+}
+
+int
+main(void)
+{
+	size_t source_len;
+	uint64_t repeats;
+	unsigned char *source = read_source(&source_len, &repeats);
+
+	if (repeats == 0) {
+		uint64_t count = 0;
+		uint64_t sum_ends = 0;
+		uint64_t weighted_ends = 0;
+		for (size_t offset = 0; offset < source_len;) {
+			offset += next_break(source, source_len, offset);
+			count++;
+			sum_ends += (uint64_t)offset;
+			weighted_ends += count * (uint64_t)offset;
+		}
+		printf("%" PRIu64 " %" PRIu64 " %" PRIu64 "\n", count,
+		       sum_ends, weighted_ends);
+		free(source);
+		return 0;
+	}
+
+	uint64_t total = 0;
+	for (uint64_t i = 0; i < repeats; i++) {
+		for (size_t offset = 0; offset < source_len;) {
+			offset += next_break(source, source_len, offset);
+			total++;
+		}
+	}
+	printf("%" PRIu64 "\n", total);
+	free(source);
+	return 0;
+}

--- a/benchmarks/grapheme/go/main.go
+++ b/benchmarks/grapheme/go/main.go
@@ -23,6 +23,21 @@ func main() {
 	}
 	source := string(input[9:])
 
+	if repeats == 0 {
+		var count uint64
+		var sumEnds uint64
+		var weightedEnds uint64
+		iterator := graphemes.FromString(source)
+		for iterator.Next() {
+			count++
+			end := uint64(iterator.End())
+			sumEnds += end
+			weightedEnds += count * end
+		}
+		fmt.Printf("%d %d %d\n", count, sumEnds, weightedEnds)
+		return
+	}
+
 	var total uint64
 	for i := uint64(0); i < repeats; i++ {
 		iterator := graphemes.FromString(source)

--- a/benchmarks/grapheme/roc/main.roc
+++ b/benchmarks/grapheme/roc/main.roc
@@ -3,6 +3,7 @@ app [run!] {
     unicode: "../../../package/main.roc",
 }
 
+import unicode.ByteRange
 import unicode.Grapheme
 
 run! : Str => Str
@@ -15,6 +16,23 @@ run! = |input| {
     repeats_str = input.drop_last_bytes(input_len - 8) ?? ...
     source = input.drop_first_bytes(9) ?? ...
     repeats = U64.from_str(repeats_str) ?? return "ERROR: invalid repeat count"
+
+    if repeats == 0 {
+        pushed = Grapheme.Cursor.push(
+            Grapheme.Cursor.init({}),
+            source,
+            { count: 0.U64, sum_ends: 0.U64, weighted_ends: 0.U64 },
+            append_signature,
+        ) ?? ...
+        finished = Grapheme.Cursor.finish(
+            pushed.cursor,
+            pushed.state,
+            append_signature,
+        ) ?? ...
+        signature = finished.state
+        return "${signature.count.to_str()} ${signature.sum_ends.to_str()} ${signature.weighted_ends.to_str()}"
+    }
+
     var remaining = repeats
     var total = 0.U64
 
@@ -35,4 +53,14 @@ run! = |input| {
     }
 
     total.to_str()
+}
+
+append_signature = |state, range| {
+    count = state.count + 1
+    end = ByteRange.end(range)
+    {
+        count,
+        sum_ends: state.sum_ends + end,
+        weighted_ends: state.weighted_ends + count * end,
+    }
 }

--- a/benchmarks/grapheme/run.py
+++ b/benchmarks/grapheme/run.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import math
 import os
@@ -12,7 +13,9 @@ import shutil
 import statistics
 import subprocess
 import sys
+import tarfile
 import time
+import urllib.request
 from pathlib import Path
 from typing import Sequence
 
@@ -25,6 +28,12 @@ DEFAULT_TARGET_BYTES = 1024 * 1024
 DEFAULT_TARGET_SECONDS = 0.40
 DEFAULT_SAMPLES = 9
 MAX_REPEATS = 99_999_999
+LIBGRAPHEME_VERSION = "3.0.0"
+LIBGRAPHEME_URL = (
+    "https://dl.suckless.org/libgrapheme/"
+    f"libgrapheme-{LIBGRAPHEME_VERSION}.tar.gz"
+)
+LIBGRAPHEME_SHA256 = "32585af73dda62fbcc0fed14f199aa1bc988ad01dad0bfbd06cf175d9cf3d68c"
 CASE_NAMES = (
     "ascii",
     "latin_combining",
@@ -70,25 +79,36 @@ def repeated(unit: str, target_bytes: int) -> bytes:
     return encoded * max(1, target_bytes // len(encoded))
 
 
-def conformance_corpus() -> tuple[bytes, int]:
+def boundary_signature(ends: Sequence[int]) -> tuple[int, int, int]:
+    return (
+        len(ends),
+        sum(ends),
+        sum(index * end for index, end in enumerate(ends, start=1)),
+    )
+
+
+def conformance_corpus() -> tuple[bytes, tuple[int, int, int]]:
     path = ROOT / "vendor/unicode/17.0.0/GraphemeBreakTest.txt"
     corpus = bytearray()
-    expected = 0
+    ends: list[int] = []
     for raw_line in path.read_text(encoding="utf-8").splitlines():
         body = raw_line.split("#", 1)[0].strip()
         if not body:
             continue
         tokens = body.split()
-        codepoints = [int(token, 16) for token in tokens if token not in {"÷", "×"}]
-        clusters = sum(token == "÷" for token in tokens) - 1
         # A control separator guarantees a boundary between adjacent test cases.
         corpus.extend(b"\0")
-        corpus.extend("".join(chr(cp) for cp in codepoints).encode("utf-8"))
-        expected += 1 + clusters
-    return bytes(corpus), expected
+        ends.append(len(corpus))
+        for index in range(1, len(tokens), 2):
+            corpus.extend(chr(int(tokens[index], 16)).encode("utf-8"))
+            if tokens[index + 1] == "÷":
+                ends.append(len(corpus))
+    return bytes(corpus), boundary_signature(ends)
 
 
-def corpora(target_bytes: int) -> tuple[dict[str, bytes], dict[str, int]]:
+def corpora(
+    target_bytes: int,
+) -> tuple[dict[str, bytes], dict[str, tuple[int, int, int]]]:
     conformance, expected = conformance_corpus()
     cases = {
         "ascii": repeated("The quick brown fox jumps over 13 lazy dogs. ", target_bytes),
@@ -112,7 +132,50 @@ def corpora(target_bytes: int) -> tuple[dict[str, bytes], dict[str, int]]:
     return cases, {"unicode17_conformance": expected}
 
 
-def build(roc: str, go: str, cargo: str, zig: str) -> dict[str, Path]:
+def file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def libgrapheme_source() -> Path:
+    archive = BUILD / f"libgrapheme-{LIBGRAPHEME_VERSION}.tar.gz"
+    source = BUILD / f"libgrapheme-{LIBGRAPHEME_VERSION}"
+    if source.is_dir():
+        return source
+
+    if not archive.is_file():
+        print(f"+ download {LIBGRAPHEME_URL}", flush=True)
+        partial = archive.with_suffix(archive.suffix + ".partial")
+        try:
+            with urllib.request.urlopen(LIBGRAPHEME_URL) as response:
+                with partial.open("wb") as output:
+                    shutil.copyfileobj(response, output)
+            partial.replace(archive)
+        finally:
+            partial.unlink(missing_ok=True)
+    actual_sha256 = file_sha256(archive)
+    if actual_sha256 != LIBGRAPHEME_SHA256:
+        raise BenchmarkFailure(
+            f"{archive} has SHA-256 {actual_sha256}, expected {LIBGRAPHEME_SHA256}"
+        )
+
+    with tarfile.open(archive, "r:gz") as package:
+        for member in package.getmembers():
+            member_path = Path(member.name)
+            if member_path.is_absolute() or ".." in member_path.parts:
+                raise BenchmarkFailure(f"unsafe path in {archive}: {member.name}")
+            if member.issym() or member.islnk():
+                raise BenchmarkFailure(f"refusing link in {archive}: {member.name}")
+        package.extractall(BUILD)
+    if not source.is_dir():
+        raise BenchmarkFailure(f"{archive} did not contain {source.name}")
+    return source
+
+
+def build(roc: str, go: str, cargo: str, zig: str, cc: str, make: str) -> dict[str, Path]:
     BUILD.mkdir(parents=True, exist_ok=True)
     command([zig, "build", "native", "-Doptimize=ReleaseFast"], cwd=ROOT / "tests/platform")
     roc_source = BENCH / "roc/main.roc"
@@ -139,10 +202,33 @@ def build(roc: str, go: str, cargo: str, zig: str) -> dict[str, Path]:
         [go, "build", "-trimpath", "-ldflags=-s -w", "-o", str(go_binary), "."],
         cwd=BENCH / "go",
     )
+
+    libgrapheme = libgrapheme_source()
+    command([make, "gen/character.h"], cwd=libgrapheme)
+    c_binary = BUILD / "c-libgrapheme"
+    command(
+        [
+            cc,
+            "-std=c99",
+            "-O3",
+            "-DNDEBUG",
+            "-flto",
+            "-I",
+            str(libgrapheme),
+            str(BENCH / "c/main.c"),
+            str(libgrapheme / "src/character.c"),
+            str(libgrapheme / "src/utf8.c"),
+            str(libgrapheme / "src/util.c"),
+            "-o",
+            str(c_binary),
+        ]
+    )
     return {
         "roc": roc_binary,
-        "rust": rust_target / "release/roc-unicode-grapheme-bench",
-        "go": go_binary,
+        "rust_unicode_segmentation": rust_target / "release/rust-unicode-segmentation",
+        "rust_icu4x": rust_target / "release/rust-icu4x",
+        "go_clipperhouse": go_binary,
+        "c_libgrapheme": c_binary,
     }
 
 
@@ -185,6 +271,32 @@ def invoke(binary: Path, corpus: bytes, repeats: int, cpu: int | None) -> tuple[
     return elapsed, checksum
 
 
+def verify_boundaries(
+    binary: Path, corpus: bytes, cpu: int | None
+) -> tuple[int, int, int]:
+    payload = b"00000000\n" + corpus
+    args = [str(binary)]
+    if cpu is not None:
+        args = ["taskset", "-c", str(cpu), *args]
+    result = subprocess.run(
+        args,
+        input=payload,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=True,
+    )
+    try:
+        count, sum_ends, weighted_ends = (
+            int(part) for part in result.stdout.decode("ascii").split()
+        )
+    except (UnicodeDecodeError, ValueError) as error:
+        raise BenchmarkFailure(
+            f"{binary} returned malformed boundary signature {result.stdout!r}; "
+            f"stderr={result.stderr.decode(errors='replace')!r}"
+        ) from error
+    return count, sum_ends, weighted_ends
+
+
 def checked_invoke(
     binary: Path,
     corpus: bytes,
@@ -221,18 +333,21 @@ def calibrate(
 def benchmark(
     binaries: dict[str, Path],
     cases: dict[str, bytes],
-    expected: dict[str, int],
+    expected: dict[str, tuple[int, int, int]],
     *,
     cpu: int | None,
     samples_count: int,
     target_seconds: float,
 ) -> dict[str, dict]:
     results: dict[str, dict] = {}
+    label_width = max(len(label) for label in binaries)
     for case_name, corpus in cases.items():
         print(f"\n[{case_name}] {len(corpus):,} bytes", flush=True)
         case_results: dict[str, dict] = {}
         one_pass_counts: dict[str, int] = {}
+        signatures: dict[str, tuple[int, int, int]] = {}
         for language, binary in binaries.items():
+            signatures[language] = verify_boundaries(binary, corpus, cpu)
             repeats, checksum = calibrate(binary, corpus, cpu, target_seconds)
             one_pass_counts[language] = checksum
             checked_invoke(binary, corpus, repeats, cpu, checksum)
@@ -250,7 +365,7 @@ def benchmark(
                 "samples_mb_per_second": samples,
             }
             print(
-                f"  {language:4s} {median:9.1f} MB/s  "
+                f"  {language:{label_width}s} {median:9.1f} MB/s  "
                 f"MAD {mad:5.1f}  n={samples_count}",
                 flush=True,
             )
@@ -259,10 +374,14 @@ def benchmark(
             raise BenchmarkFailure(
                 f"{case_name}: implementations disagree on cluster counts: {one_pass_counts}"
             )
-        if case_name in expected and next(iter(one_pass_counts.values())) != expected[case_name]:
+        if len(set(signatures.values())) != 1:
             raise BenchmarkFailure(
-                f"{case_name}: Unicode 17 expected {expected[case_name]} clusters, "
-                f"got {one_pass_counts}"
+                f"{case_name}: implementations disagree on boundary positions: {signatures}"
+            )
+        if case_name in expected and next(iter(signatures.values())) != expected[case_name]:
+            raise BenchmarkFailure(
+                f"{case_name}: Unicode 17 expected boundary signature "
+                f"{expected[case_name]}, got {signatures}"
             )
         results[case_name] = {"bytes": len(corpus), "implementations": case_results}
     return results
@@ -311,7 +430,7 @@ def print_comparison(current: dict, baseline: dict, baseline_path: Path) -> None
         print("WARNING: baseline and current target corpus sizes differ", file=sys.stderr)
 
     print(f"\nComparison with {baseline_path}:")
-    print(f"{'case':28s} {'impl':5s} {'baseline':>11s} {'current':>11s} {'delta':>9s}")
+    print(f"{'case':28s} {'implementation':27s} {'baseline':>11s} {'current':>11s} {'delta':>9s}")
     for case_name, current_case in current_cases.items():
         baseline_case = baseline_cases.get(case_name)
         if not isinstance(baseline_case, dict):
@@ -332,7 +451,7 @@ def print_comparison(current: dict, baseline: dict, baseline_path: Path) -> None
             after = float(current_impl["mb_per_second_median"])
             delta = (after / before - 1.0) * 100.0
             print(
-                f"{case_name:28s} {language:5s} "
+                f"{case_name:28s} {language:27s} "
                 f"{before:9.1f} MB/s {after:9.1f} MB/s {delta:+8.1f}%"
             )
 
@@ -343,6 +462,8 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--go", default="go")
     parser.add_argument("--cargo", default="cargo")
     parser.add_argument("--zig", default="zig")
+    parser.add_argument("--cc", default="cc")
+    parser.add_argument("--make", default="make")
     parser.add_argument("--skip-build", action="store_true")
     parser.add_argument("--samples", type=int, default=DEFAULT_SAMPLES)
     parser.add_argument("--target-seconds", type=float, default=DEFAULT_TARGET_SECONDS)
@@ -370,14 +491,19 @@ def main() -> None:
     args.go = resolve_tool(args.go)
     args.cargo = resolve_tool(args.cargo)
     args.zig = resolve_tool(args.zig)
+    args.cc = resolve_tool(args.cc)
+    args.make = resolve_tool(args.make)
     binaries = (
         {
             "roc": BUILD / "roc",
-            "rust": BUILD / "rust-target/release/roc-unicode-grapheme-bench",
-            "go": BUILD / "go",
+            "rust_unicode_segmentation": BUILD
+            / "rust-target/release/rust-unicode-segmentation",
+            "rust_icu4x": BUILD / "rust-target/release/rust-icu4x",
+            "go_clipperhouse": BUILD / "go",
+            "c_libgrapheme": BUILD / "c-libgrapheme",
         }
         if args.skip_build
-        else build(args.roc, args.go, args.cargo, args.zig)
+        else build(args.roc, args.go, args.cargo, args.zig, args.cc, args.make)
     )
     missing = [str(path) for path in binaries.values() if not path.is_file()]
     if missing:
@@ -406,10 +532,13 @@ def main() -> None:
             "cargo": capture([args.cargo, "--version"]),
             "go": capture([args.go, "version"]),
             "zig": capture([args.zig, "version"]),
+            "cc": capture([args.cc, "--version"]),
         },
         "libraries": {
             "unicode_segmentation": "1.13.3 (Unicode 17)",
+            "icu_segmenter": "2.2.0 (Unicode 17)",
             "clipperhouse_uax29": "2.7.0 (Unicode 17)",
+            "libgrapheme": "3.0.0 (Unicode 17)",
         },
         "configuration": {
             "samples": args.samples,

--- a/benchmarks/grapheme/rust/Cargo.lock
+++ b/benchmarks/grapheme/rust/Cargo.lock
@@ -3,14 +3,323 @@
 version = 4
 
 [[package]]
+name = "displaydoc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5a396343c7208121dc86e35623d3dfe19814a7613cfd14964994cdc9c9a2e26"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_locale_data",
+ "icu_provider",
+ "potential_utf",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "serde",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fdcc9ac77c6d74ff5cf6e65ef3181d6af32003b16fce3a77fb451d2f695993"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "serde",
+ "stable_deref_trait",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_segmenter"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c0794db0b1a86193ac9c48768d0e6c52c54448e0870ad87907d456ee0dac964"
+dependencies = [
+ "icu_collections",
+ "icu_locale",
+ "icu_provider",
+ "icu_segmenter_data",
+ "potential_utf",
+ "utf8_iter",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_segmenter_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4a2c462a4d927d512f5f882a033ddd62f33a05bb9f230d98f736ac3dc85938f"
+
+[[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "serde_core",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.107"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
 name = "roc-unicode-grapheme-bench"
 version = "0.0.0"
 dependencies = [
+ "icu_segmenter",
  "unicode-segmentation",
 ]
+
+[[package]]
+name = "serde"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "syn"
+version = "2.0.119"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "serde_core",
+ "zerovec",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
 version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "yoke"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "synstructure",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "synstructure",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "serde",
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]

--- a/benchmarks/grapheme/rust/Cargo.toml
+++ b/benchmarks/grapheme/rust/Cargo.toml
@@ -5,7 +5,16 @@ edition = "2024"
 publish = false
 
 [dependencies]
+icu_segmenter = { version = "=2.2.0", default-features = false, features = ["compiled_data"] }
 unicode-segmentation = "=1.13.3"
+
+[[bin]]
+name = "rust-unicode-segmentation"
+path = "src/main.rs"
+
+[[bin]]
+name = "rust-icu4x"
+path = "src/icu4x.rs"
 
 [profile.release]
 codegen-units = 1

--- a/benchmarks/grapheme/rust/src/icu4x.rs
+++ b/benchmarks/grapheme/rust/src/icu4x.rs
@@ -1,6 +1,6 @@
+use icu_segmenter::GraphemeClusterSegmenter;
 use std::hint::black_box;
 use std::io::{self, Read};
-use unicode_segmentation::UnicodeSegmentation;
 
 fn main() {
     let mut input = String::new();
@@ -8,15 +8,15 @@ fn main() {
     let repeats: u64 = input[..8].parse().expect("invalid repeat count");
     assert_eq!(input.as_bytes()[8], b'\n');
     let source = &input[9..];
+    let segmenter = GraphemeClusterSegmenter::new();
 
     if repeats == 0 {
         let mut count = 0u64;
         let mut sum_ends = 0u64;
         let mut weighted_ends = 0u64;
-        let mut end = 0u64;
-        for grapheme in source.graphemes(true) {
+        for end in segmenter.segment_str(source).skip(1) {
             count += 1;
-            end += grapheme.len() as u64;
+            let end = end as u64;
             sum_ends += end;
             weighted_ends += count * end;
         }
@@ -26,7 +26,8 @@ fn main() {
 
     let mut total = 0u64;
     for _ in 0..repeats {
-        total = total.wrapping_add(black_box(source).graphemes(true).count() as u64);
+        let boundaries = black_box(&segmenter).segment_str(black_box(source)).count();
+        total = total.wrapping_add(boundaries.saturating_sub(1) as u64);
     }
     println!("{}", black_box(total));
 }


### PR DESCRIPTION
## Summary

- expand the local grapheme benchmark with ICU4X 2.2.0 and libgrapheme 3.0.0
- retain clipperhouse/uax29 as the specialized Go baseline and unicode-segmentation as a general-purpose Rust reference
- compare allocation-free iterator or next-boundary APIs over identical Unicode 17 UTF-8 corpora
- verify a signature derived from every boundary position before timing, including the official GraphemeBreakTest.txt expectations
- keep downloaded sources, binaries, and machine-specific benchmark results ignored and out of CI

## Comparison design

This is an implementation comparison, not a language comparison. The two Rust implementations intentionally demonstrate the effect of API and algorithm design within one language.

The retained set is a representative practical frontier of Unicode 17 implementations with iterator or next-boundary APIs; it is not a claim to exhaust every Unicode library. libgrapheme is downloaded at a pinned version into the ignored build directory, SHA-256 verified, and compiled with optimization and LTO.

This changes benchmark tooling only. It does not change package APIs, Unicode data, or runtime behavior.

Per AGENTS.md, this remains a draft and requires independent adversarial review against design.md before merge.

## Validation

- clean build and all-corpus smoke run for Roc, ICU4X, unicode-segmentation, clipperhouse/uax29, and libgrapheme
- full default benchmark run; all five implementations agreed on boundary signatures for every corpus
- Roc Unicode 17 grapheme conformance suite: 766/766 cases
- Unicode data generation check and package examples passed through the project test wrapper
- exact allocation tests skipped by the wrapper because the installed Roc build does not match the pinned nightly
- Python compile, cargo fmt, gofmt, and git diff checks
