### PR TITLE
Establish coverage-guided fuzzing foundation

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -17,6 +17,25 @@ env:
   ZIG_VERSION: "0.16.0"
 
 jobs:
+  fuzz-smoke:
+    name: Coverage-guided fuzz smoke (Linux x64)
+    runs-on: ubuntu-26.04
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Read pinned Roc version
+        run: printf 'ROC_NIGHTLY_TAG=%s\n' "$(sed -n '1p' .roc-version)" >> "$GITHUB_ENV"
+
+      - uses: roc-lang/setup-roc@cbe782d6f165b89c87d99f50a59ac4f5f73b4427
+        with:
+          version: nightly-new-compiler
+          nightly-tag: ${{ env.ROC_NIGHTLY_TAG }}
+
+      - name: Run bounded fuzz smoke
+        run: ROC=roc python3 scripts/fuzz.py smoke
+
   test:
     name: ./scripts/all_tests.sh (${{ matrix.os }})
     runs-on: ${{ matrix.os }}

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ tests/platform/targets/arm64v1musl/libc.a
 dist/
 __pycache__/
 .roc-unicode-tmp/
+.roc-fuzz/
 
 # Ignore local benchmark build output
 benchmarks/grapheme/rust/target/

--- a/.roc-version
+++ b/.roc-version
@@ -1,1 +1,1 @@
-nightly-2026-August-05-24f0b47
+nightly-2026-08-08-195c9e7

--- a/fuzz/FuzzSupport.roc
+++ b/fuzz/FuzzSupport.roc
@@ -1,0 +1,100 @@
+import fuzz.Fuzz
+import unicode.Scalar
+
+FuzzSupport := [].{
+
+	## Stable fuzz-only encoding for valid Unicode scalar sequences.
+	##
+	## Every three little-endian entropy bytes select one of the 1,112,064
+	## Unicode scalar values. Ranks above U+D7FF skip the surrogate range. A
+	## trailing group is zero-padded, so every input byte contributes to a value.
+	scalar_sequence : Fuzz.Generator(List(U32))
+	scalar_sequence = Fuzz.map(Fuzz.raw_bytes, scalar_sequence_from_bytes)
+
+	scalar_sequence_from_bytes : List(U8) -> List(U32)
+	scalar_sequence_from_bytes = |bytes| {
+		var $remaining = bytes
+		var $scalars = []
+		while !$remaining.is_empty() {
+			(b0, b1, b2, rest) = match $remaining {
+				[first, second, third, .. as tail] => (first, second, third, tail)
+				[first, second] => (first, second, 0, [])
+				[first] => (first, 0, 0, [])
+				[] => (0, 0, 0, [])
+			}
+			raw = b0.to_u32().bitwise_or(b1.to_u32().shl_wrap(8)).bitwise_or(b2.to_u32().shl_wrap(16))
+			rank = raw % 0x10F800
+			code_point = if rank <= 0xD7FF rank else rank + 0x800
+			$scalars = $scalars.append(code_point)
+			$remaining = rest
+		}
+		$scalars
+	}
+
+	source_parts : List(U32) -> List(Str)
+	source_parts = |code_points| {
+		code_points.map(
+			|code_point| {
+				scalar = Scalar.from_u32(code_point) ?? crash "fuzz scalar encoding admitted an invalid scalar"
+				Scalar.to_str(scalar) ?? crash "fuzz scalar encoding could not produce UTF-8"
+			},
+		)
+	}
+
+	source : List(U32) -> Str
+	source = |code_points| Str.join_with(source_parts(code_points), "")
+
+	show_scalars : List(U32) -> Str
+	show_scalars = |code_points| {
+		labels = code_points.map(|code_point| "U+${hex_scalar(code_point)}")
+		"code_points=[${Str.join_with(labels, ", ")}] text=${Str.inspect(source(code_points))}"
+	}
+
+	show_bytes : List(U8) -> Str
+	show_bytes = |bytes| {
+		hex = bytes.map(|byte| pad_hex(byte.to_u32(), 2))
+		"bytes=${bytes.len().to_str()} hex=${Str.join_with(hex, " ")}"
+	}
+
+	hex_scalar : U32 -> Str
+	hex_scalar = |value| pad_hex(value, 4)
+
+	pad_hex : U32, U64 -> Str
+	pad_hex = |value, minimum| {
+		var $remaining = value
+		var $text = ""
+		while $remaining > 0 {
+			digit = hex_digit($remaining % 16)
+			$text = "${digit}${$text}"
+			$remaining = $remaining / 16
+		}
+		if $text == "" {
+			$text = "0"
+		}
+		while $text.count_utf8_bytes() < minimum {
+			$text = "0${$text}"
+		}
+		$text
+	}
+
+	hex_digit : U32 -> Str
+	hex_digit = |value| match value {
+		0 => "0"
+		1 => "1"
+		2 => "2"
+		3 => "3"
+		4 => "4"
+		5 => "5"
+		6 => "6"
+		7 => "7"
+		8 => "8"
+		9 => "9"
+		10 => "A"
+		11 => "B"
+		12 => "C"
+		13 => "D"
+		14 => "E"
+		15 => "F"
+		_ => "?"
+	}
+}

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -1,0 +1,81 @@
+# Coverage-guided fuzzing
+
+This directory is the initial coverage-guided fuzzing layer for the Unicode
+package. It uses the compiler-native sanitizer coverage enabled by
+`roc build --fuzz` and the self-contained libFuzzer runner from
+[`roc-fuzz` 0.2.0](https://github.com/lukewilliamboswell/roc-fuzz/releases/tag/0.2.0).
+The compiler therefore instruments the compiled Roc application and Unicode
+algorithm code, rather than observing only a platform host.
+
+This replaces issue #50's earlier AFL++ instrumentation spike. Deterministic
+Unicode conformance tests remain authoritative and continue to live in their
+feature suites; fuzzing adds adversarial inputs and metamorphic invariants.
+
+## Initial targets
+
+`utf8` receives every fuzzer byte unchanged. It compares whole-input,
+one-byte-chunk, and one-scalar-stop/resume executions of `Utf8.Cursor`. Emitted
+scalars must re-encode to their exact source ranges, successful results must
+agree with `Str.from_utf8`, malformed offsets must agree across driving modes,
+and terminal cursors must remain sealed.
+
+`grapheme` is a separate valid-text domain. Each three little-endian fuzzer
+bytes select one scalar rank; ranks above `U+D7FF` skip the surrogate range.
+The target compares iterator, collector, materializer, whole-chunk cursor, and
+scalar-chunk cursor results. Ranges must form a lossless scalar-aligned
+partition, and every materialized cluster must be idempotent under
+segmentation.
+
+The smoke runner limits UTF-8 artifacts to 512 bytes and grapheme artifacts to
+384 entropy bytes (at most 128 scalars). Each target is pure, bounded, and
+designed for libFuzzer's in-process execution model.
+
+## Commands
+
+Every command checks the selected compiler against the repository's sole Roc
+pin in `.roc-version`:
+
+```sh
+ROC=roc python3 scripts/fuzz.py build
+ROC=roc python3 scripts/fuzz.py smoke
+ROC=roc python3 scripts/fuzz.py campaign grapheme -- --time=3600
+ROC=roc python3 scripts/fuzz.py reproduce grapheme .roc-fuzz/crash-HASH
+ROC=roc python3 scripts/fuzz.py minimize grapheme INPUT OUTPUT
+```
+
+`smoke` builds each optimized target once, materializes a fresh seed corpus,
+and runs 2,000 mutations with fixed seed, size, timeout, and RSS bounds. CI runs
+this smoke on Linux x86-64 only. Apple Silicon macOS remains supported for
+local campaigns by the selected roc-fuzz release.
+
+`campaign` retains discoveries under `.roc-unicode-tmp/fuzz/corpus`. The
+`reproduce` command prints the raw artifact bytes, renders the typed input with
+the target's `show` function, and replays it in a fresh process.
+
+## Seeds and regressions
+
+`seeds.json` stores reviewable hexadecimal sources. UTF-8 entries are copied
+unchanged. Grapheme entries must be valid UTF-8 and are converted to the
+target's stable three-byte scalar encoding. The runner also imports every
+sequence from the pinned Unicode 17 `GraphemeBreakTest.txt`, plus the historical
+crash inputs from issue #19 and the pirate-flag data-loss input from issue #22.
+
+After finding a failure:
+
+1. Replay it in a fresh process.
+2. Minimize the raw artifact.
+3. Add a named source to `seeds.json` so future campaigns retain it.
+4. Add an exact deterministic regression to the owning feature suite once the
+   expected behavior is understood.
+
+Corpus entries are coverage inputs, not correctness oracles. Exact edge counts
+and executions per second are intentionally not checked into the repository;
+the smoke log must show coverage activity, but compiler and layout changes may
+legitimately change those measurements.
+
+## Deferred work
+
+Line breaking, property scans, Script itemization, bidi, structured chunk
+plans and limits, Unicode-version-matched differential oracles, corpus
+reduction automation, artifact upload, and resource-guarded long scheduled
+campaigns remain follow-up work under issue #50.

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -3,7 +3,7 @@
 This directory is the initial coverage-guided fuzzing layer for the Unicode
 package. It uses the compiler-native sanitizer coverage enabled by
 `roc build --fuzz` and the self-contained libFuzzer runner from
-[`roc-fuzz` 0.2.0](https://github.com/lukewilliamboswell/roc-fuzz/releases/tag/0.2.0).
+[`roc-fuzz` 0.2.1](https://github.com/lukewilliamboswell/roc-fuzz/releases/tag/0.2.1).
 The compiler therefore instruments the compiled Roc application and Unicode
 algorithm code, rather than observing only a platform host.
 

--- a/fuzz/grapheme.roc
+++ b/fuzz/grapheme.roc
@@ -1,5 +1,5 @@
 app [target] {
-	fuzz: platform "https://github.com/lukewilliamboswell/roc-fuzz/releases/download/0.2.0/9xpnP9ZqhuLk2D2LcYCFbqdkN3cpaKhERdoesPPrfKyM.tar.zst",
+	fuzz: platform "https://github.com/lukewilliamboswell/roc-fuzz/releases/download/0.2.1/9Qpttb6LTgcMaVsSBLsnaiS2mDUrf6Bxa6dX9Rqwviz4.tar.zst",
 	unicode: "../package/main.roc",
 }
 

--- a/fuzz/grapheme.roc
+++ b/fuzz/grapheme.roc
@@ -1,0 +1,117 @@
+app [target] {
+	fuzz: platform "https://github.com/lukewilliamboswell/roc-fuzz/releases/download/0.2.0/9xpnP9ZqhuLk2D2LcYCFbqdkN3cpaKhERdoesPPrfKyM.tar.zst",
+	unicode: "../package/main.roc",
+}
+
+import FuzzSupport
+import fuzz.Fuzz
+import unicode.ByteRange
+import unicode.Grapheme
+
+test : List(U32) -> Fuzz.Outcome
+test = |code_points| {
+	parts = FuzzSupport.source_parts(code_points)
+	source = Str.join_with(parts, "")
+	collected = Grapheme.ranges(source)
+	iterated = Grapheme.iter_ranges(source).fold([], |ranges, range| ranges.append(range))
+	whole_cursor = cursor_ranges([source])
+	scalar_cursor = cursor_ranges([""].concat(parts).append(""))
+
+	if iterated != collected {
+		crash "Grapheme.iter_ranges disagreed with Grapheme.ranges"
+	}
+	if whole_cursor != collected {
+		crash "whole-chunk Grapheme.Cursor disagreed with Grapheme.ranges"
+	}
+	if scalar_cursor != collected {
+		crash "scalar-chunk Grapheme.Cursor disagreed with Grapheme.ranges"
+	}
+
+	validate_partition(source, collected)
+	expected_materialized = materialize(source, collected)
+	if Grapheme.slices(source) != expected_materialized {
+		crash "Grapheme.slices disagreed with range materialization"
+	}
+	if Grapheme.owned(source) != expected_materialized {
+		crash "Grapheme.owned disagreed with range materialization"
+	}
+	if Str.join_with(expected_materialized, "") != source {
+		crash "grapheme materialization lost or changed source text"
+	}
+
+	for cluster in expected_materialized {
+		inner = Grapheme.ranges(cluster)
+		if inner.len() != 1 {
+			crash "a grapheme cluster was not idempotent under segmentation"
+		}
+		only = inner.get(0) ?? crash "one grapheme range could not be read"
+		if ByteRange.start(only) != 0 or ByteRange.end(only) != cluster.count_utf8_bytes() {
+			crash "an idempotent grapheme range did not cover its cluster"
+		}
+	}
+
+	Fuzz.keep
+}
+
+cursor_ranges : List(Str) -> List(ByteRange)
+cursor_ranges = |chunks| {
+	var $cursor = Grapheme.Cursor.init({})
+	var $ranges = []
+	for chunk in chunks {
+		pushed = Grapheme.Cursor.push($cursor, chunk, $ranges, |ranges, range| ranges.append(range))
+		match pushed {
+			Err(_) => crash "Grapheme.Cursor.push failed for scalar-aligned input"
+			Ok(next) => {
+				$cursor = next.cursor
+				$ranges = next.state
+			}
+		}
+	}
+	finished = Grapheme.Cursor.finish($cursor, $ranges, |ranges, range| ranges.append(range))
+	match finished {
+		Err(_) => crash "Grapheme.Cursor.finish failed for an open cursor"
+		Ok(done) => {
+			match Grapheme.Cursor.finish(done.cursor, [], |ranges, range| ranges.append(range)) {
+				Err(AlreadyFinished) => {}
+				_ => crash "Grapheme.Cursor was not sealed after finish"
+			}
+			done.state
+		}
+	}
+}
+
+validate_partition : Str, List(ByteRange) -> {}
+validate_partition = |source, ranges| {
+	if source == "" and !ranges.is_empty() {
+		crash "empty text produced a grapheme range"
+	}
+	if source != "" and ranges.is_empty() {
+		crash "nonempty text produced no grapheme ranges"
+	}
+	var $next_start = 0
+	for range in ranges {
+		start = ByteRange.start(range)
+		end = ByteRange.end(range)
+		if start != $next_start or end <= start {
+			crash "grapheme ranges were empty, overlapping, or discontinuous"
+		}
+		_ = ByteRange.slice(range, source) ?? crash "grapheme range was not scalar-aligned and in bounds"
+		$next_start = end
+	}
+	if $next_start != source.count_utf8_bytes() {
+		crash "grapheme ranges did not cover the complete source"
+	}
+	{}
+}
+
+materialize : Str, List(ByteRange) -> List(Str)
+materialize = |source, ranges| {
+	ranges.map(|range| ByteRange.slice(range, source) ?? crash "validated grapheme range could not be sliced")
+}
+
+target = Fuzz.target_with({
+	name: "unicode-grapheme",
+	generator: FuzzSupport.scalar_sequence,
+	test,
+	show: FuzzSupport.show_scalars,
+})

--- a/fuzz/seeds.json
+++ b/fuzz/seeds.json
@@ -1,0 +1,38 @@
+{
+  "schema_version": 1,
+  "utf8": [
+    { "name": "empty", "bytes_hex": "" },
+    { "name": "ascii", "bytes_hex": "00417F" },
+    { "name": "two-byte-boundaries", "bytes_hex": "C280DFBF" },
+    { "name": "three-byte-boundaries", "bytes_hex": "E0A080EFBFBF" },
+    { "name": "four-byte-boundaries", "bytes_hex": "F0908080F48FBFBF" },
+    { "name": "unexpected-continuation", "bytes_hex": "80" },
+    { "name": "invalid-start", "bytes_hex": "FF" },
+    { "name": "expected-continuation", "bytes_hex": "E228A1" },
+    { "name": "overlong-two", "bytes_hex": "C080" },
+    { "name": "overlong-three", "bytes_hex": "E08080" },
+    { "name": "surrogate", "bytes_hex": "EDA080" },
+    { "name": "code-point-too-large", "bytes_hex": "F4908080" },
+    { "name": "truncated-two", "bytes_hex": "C2" },
+    { "name": "truncated-three", "bytes_hex": "E282" },
+    { "name": "truncated-four", "bytes_hex": "F09F92" }
+  ],
+  "grapheme": [
+    { "name": "scalar-width-boundaries", "bytes_hex": "007FC280DFBFE0A080ED9FBFEE8080EFBFBFF0908080F48FBFBF" },
+    { "name": "issue-19-01", "bytes_hex": "0DCC88E186A8E2808DEAB081" },
+    { "name": "issue-19-02", "bytes_hex": "E0B98301E185A0E2808DE0A480" },
+    { "name": "issue-19-03", "bytes_hex": "E18480E2808DCC88E0A58D" },
+    { "name": "issue-19-04", "bytes_hex": "E18480E2808DCC881F" },
+    { "name": "issue-19-05", "bytes_hex": "E185A0E2808DCC88CDB8" },
+    { "name": "issue-19-06", "bytes_hex": "E185A0E2808DE0A495" },
+    { "name": "issue-19-07", "bytes_hex": "E186A8E2808D0A" },
+    { "name": "issue-19-08", "bytes_hex": "E186A8E2808DE18581" },
+    { "name": "issue-19-09", "bytes_hex": "EAB080E2808DE0A58D" },
+    { "name": "issue-19-10", "bytes_hex": "EAB080E2808DE0B58E" },
+    { "name": "issue-19-11", "bytes_hex": "EAB081E2808DCC88F09F87A6" },
+    { "name": "issue-19-12", "bytes_hex": "EAB081E2808DE186A8" },
+    { "name": "issue-19-13", "bytes_hex": "EAB081E2808D24" },
+    { "name": "issue-19-14", "bytes_hex": "F3A081AEEAB080E2808DE0A4BC" },
+    { "name": "issue-22-pirate-flags", "bytes_hex": "F09F8FB4E2808DE298A0EFB88FF09F8F81F09F8E8CF09F9AA9F09F8FB3EFB88FE2808DF09F8C88" }
+  ]
+}

--- a/fuzz/utf8.roc
+++ b/fuzz/utf8.roc
@@ -1,0 +1,209 @@
+app [target] {
+	fuzz: platform "https://github.com/lukewilliamboswell/roc-fuzz/releases/download/0.2.0/9xpnP9ZqhuLk2D2LcYCFbqdkN3cpaKhERdoesPPrfKyM.tar.zst",
+	unicode: "../package/main.roc",
+}
+
+import FuzzSupport
+import fuzz.Fuzz
+import unicode.ByteRange
+import unicode.Scalar
+import unicode.Utf8
+
+Item : { value : U32, start : U64, end : U64, index : U64 }
+
+Terminal : [
+	Complete({ byte_offset : U64, scalar_count : U64, sealed : Bool }),
+	MalformedInput({ problem : U8, offset : U64, sequence_start : U64, sealed : Bool }),
+	UnexpectedFailure({ kind : U8, at : U64, sealed : Bool }),
+]
+
+Trace : { items : List(Item), terminal : Terminal }
+
+test : List(U8) -> Fuzz.Outcome
+test = |bytes| {
+	whole = decode_whole(bytes)
+	chunked = decode_byte_chunks(bytes)
+	stopped = decode_with_stops(bytes)
+
+	if whole != chunked {
+		crash "Utf8.Cursor whole and byte-chunk decoding disagreed"
+	}
+	if whole != stopped {
+		crash "Utf8.Cursor Continue and Stop/resume decoding disagreed"
+	}
+	validate_trace(bytes, whole)
+	Fuzz.keep
+}
+
+decode_whole : List(U8) -> Trace
+decode_whole = |bytes| {
+	pushed = Utf8.Cursor.push(Utf8.Cursor.init({}), bytes, [], append_item)
+	match pushed {
+		Pushed(next) => finish_trace(next.cursor, next.state)
+		Stopped(_) => crash "Continue callback unexpectedly stopped UTF-8 decoding"
+		Failed(failure) => failed_trace(failure.cursor, failure.state, failure.error)
+	}
+}
+
+decode_byte_chunks : List(U8) -> Trace
+decode_byte_chunks = |bytes| {
+	var $cursor = Utf8.Cursor.init({})
+	var $items = []
+	for byte in bytes {
+		match Utf8.Cursor.push($cursor, [byte], $items, append_item) {
+			Pushed(next) => {
+				$cursor = next.cursor
+				$items = next.state
+			}
+			Stopped(_) => crash "Continue callback unexpectedly stopped chunked UTF-8 decoding"
+			Failed(failure) => return failed_trace(failure.cursor, failure.state, failure.error)
+		}
+	}
+	finish_trace($cursor, $items)
+}
+
+decode_with_stops : List(U8) -> Trace
+decode_with_stops = |bytes| {
+	var $cursor = Utf8.Cursor.init({})
+	var $remaining = bytes
+	var $items = []
+	while Bool.True {
+		match Utf8.Cursor.push($cursor, $remaining, $items, |items, located| Stop(items.append(item_shape(located)))) {
+			Pushed(next) => return finish_trace(next.cursor, next.state)
+			Stopped(next) => {
+				if next.consumed == 0 {
+					crash "Utf8.Cursor stopped without consuming a scalar"
+				}
+				$cursor = next.cursor
+				$items = next.state
+				$remaining = $remaining.drop_first(next.consumed)
+				if $remaining.is_empty() {
+					return finish_trace($cursor, $items)
+				}
+			}
+			Failed(failure) => return failed_trace(failure.cursor, failure.state, failure.error)
+		}
+	}
+}
+
+append_item = |items, located| Continue(items.append(item_shape(located)))
+
+item_shape = |located| {
+	range = located.byte_range
+	{
+		value: Scalar.to_u32(located.scalar),
+		start: ByteRange.start(range),
+		end: ByteRange.end(range),
+		index: located.scalar_index,
+	}
+}
+
+finish_trace : Utf8.Cursor, List(Item) -> Trace
+finish_trace = |cursor, items| {
+	match Utf8.Cursor.finish(cursor) {
+		End(done) => {
+			sealed_finish = match Utf8.Cursor.finish(done.cursor) {
+				Failed({ error: AlreadyFinished, .. }) => Bool.True
+				_ => Bool.False
+			}
+			sealed_push = match Utf8.Cursor.push(done.cursor, [], {}, |state, _| Continue(state)) {
+				Failed({ error: AlreadyFinished, consumed: 0, .. }) => Bool.True
+				_ => Bool.False
+			}
+			{
+				items,
+				terminal: Complete({
+					byte_offset: done.byte_offset,
+					scalar_count: done.scalar_count,
+					sealed: sealed_finish and sealed_push,
+				}),
+			}
+		}
+		Failed(failure) => failed_trace(failure.cursor, items, failure.error)
+	}
+}
+
+failed_trace : Utf8.Cursor, List(Item), Utf8.Cursor.Error -> Trace
+failed_trace = |cursor, items, error| {
+	sealed_finish = match Utf8.Cursor.finish(cursor) {
+		Failed({ error: AlreadyFailed, .. }) => Bool.True
+		_ => Bool.False
+	}
+	sealed_push = match Utf8.Cursor.push(cursor, [], {}, |state, _| Continue(state)) {
+		Failed({ error: AlreadyFailed, consumed: 0, .. }) => Bool.True
+		_ => Bool.False
+	}
+	sealed = sealed_finish and sealed_push
+	terminal = match error {
+		Malformed(details) => MalformedInput({
+			problem: problem_code(details.problem),
+			offset: details.offset,
+			sequence_start: details.sequence_start,
+			sealed,
+		})
+		OffsetOverflow({ at }) => UnexpectedFailure({ kind: 1, at, sealed })
+		ScalarIndexOverflow({ at }) => UnexpectedFailure({ kind: 2, at, sealed })
+		AlreadyFinished => UnexpectedFailure({ kind: 3, at: 0, sealed })
+		AlreadyFailed => UnexpectedFailure({ kind: 4, at: 0, sealed })
+		InternalFault => UnexpectedFailure({ kind: 5, at: 0, sealed })
+	}
+	{ items, terminal }
+}
+
+problem_code = |problem| match problem {
+	InvalidStartByte => 1
+	UnexpectedEndOfSequence => 2
+	ExpectedContinuation => 3
+	OverlongEncoding => 4
+	EncodesSurrogateHalf => 5
+	CodePointTooLarge => 6
+}
+
+validate_trace : List(U8), Trace -> {}
+validate_trace = |bytes, trace| {
+	var $expected_start = 0
+	var $expected_index = 0
+	for item in trace.items {
+		if item.start != $expected_start or item.end <= item.start or item.index != $expected_index {
+			crash "Utf8.Cursor emitted discontinuous ranges or scalar indices"
+		}
+		scalar = Scalar.from_u32(item.value) ?? crash "Utf8.Cursor emitted a non-scalar value"
+		encoded = Scalar.to_utf8(scalar)
+		selected = bytes.drop_first(item.start).take_first(item.end - item.start)
+		if encoded != selected {
+			crash "Utf8.Cursor scalar did not re-encode to its source range"
+		}
+		$expected_start = item.end
+		$expected_index = item.index + 1
+	}
+
+	match trace.terminal {
+		Complete(done) => {
+			if !done.sealed or done.byte_offset != bytes.len() or done.scalar_count != trace.items.len() or $expected_start != bytes.len() {
+				crash "successful Utf8.Cursor completion reported inconsistent coordinates"
+			}
+			match Str.from_utf8(bytes) {
+				Err(_) => crash "Utf8.Cursor accepted bytes rejected by Str.from_utf8"
+				Ok(_) => {}
+			}
+		}
+		MalformedInput(details) => {
+			if !details.sealed or details.sequence_start != $expected_start or details.sequence_start > details.offset or details.offset > bytes.len() {
+				crash "malformed UTF-8 reported inconsistent offsets or terminal state"
+			}
+			match Str.from_utf8(bytes) {
+				Ok(_) => crash "Utf8.Cursor rejected bytes accepted by Str.from_utf8"
+				Err(_) => {}
+			}
+		}
+		UnexpectedFailure(_) => crash "finite fuzz input reached an unexpected Utf8.Cursor failure"
+	}
+	{}
+}
+
+target = Fuzz.target_with({
+	name: "unicode-utf8",
+	generator: Fuzz.raw_bytes,
+	test,
+	show: FuzzSupport.show_bytes,
+})

--- a/fuzz/utf8.roc
+++ b/fuzz/utf8.roc
@@ -1,5 +1,5 @@
 app [target] {
-	fuzz: platform "https://github.com/lukewilliamboswell/roc-fuzz/releases/download/0.2.0/9xpnP9ZqhuLk2D2LcYCFbqdkN3cpaKhERdoesPPrfKyM.tar.zst",
+	fuzz: platform "https://github.com/lukewilliamboswell/roc-fuzz/releases/download/0.2.1/9Qpttb6LTgcMaVsSBLsnaiS2mDUrf6Bxa6dX9Rqwviz4.tar.zst",
 	unicode: "../package/main.roc",
 }
 

--- a/scripts/fuzz.py
+++ b/scripts/fuzz.py
@@ -86,7 +86,7 @@ def verify_host() -> None:
     )
     if not supported:
         raise FuzzFailure(
-            "roc-fuzz 0.2.0 supports Linux x86-64 and Apple Silicon macOS; "
+            "roc-fuzz 0.2.1 supports Linux x86-64 and Apple Silicon macOS; "
             f"this host reports {system} {machine}"
         )
 

--- a/scripts/fuzz.py
+++ b/scripts/fuzz.py
@@ -1,0 +1,310 @@
+#!/usr/bin/env python3
+"""Build and operate roc-unicode's coverage-guided fuzz targets."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import platform
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Sequence
+
+import unicode_data
+
+
+ROOT = Path(__file__).resolve().parents[1]
+FUZZ_ROOT = ROOT / "fuzz"
+WORK_ROOT = ROOT / ".roc-unicode-tmp" / "fuzz"
+BIN_ROOT = WORK_ROOT / "bin"
+PERSISTENT_CORPUS_ROOT = WORK_ROOT / "corpus"
+SEED_PATH = FUZZ_ROOT / "seeds.json"
+NAME_PATTERN = re.compile(r"[a-z0-9]+(?:-[a-z0-9]+)*\Z")
+
+
+class FuzzFailure(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class Target:
+    name: str
+    source: Path
+    max_input_size: int
+
+    @property
+    def binary(self) -> Path:
+        suffix = ".exe" if os.name == "nt" else ""
+        return BIN_ROOT / f"unicode-{self.name}{suffix}"
+
+
+TARGETS = {
+    "utf8": Target("utf8", FUZZ_ROOT / "utf8.roc", 512),
+    "grapheme": Target("grapheme", FUZZ_ROOT / "grapheme.roc", 384),
+}
+
+
+def command(
+    args: Sequence[str | Path],
+    *,
+    cwd: Path = ROOT,
+    capture: bool = False,
+) -> subprocess.CompletedProcess[str]:
+    values = [str(value) for value in args]
+    print("+", " ".join(values), flush=True)
+    completed = subprocess.run(
+        values,
+        cwd=cwd,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        stdout=subprocess.PIPE if capture else None,
+        stderr=subprocess.STDOUT if capture else None,
+        check=False,
+    )
+    if completed.returncode != 0:
+        if capture and completed.stdout:
+            print(completed.stdout, end="" if completed.stdout.endswith("\n") else "\n")
+        raise FuzzFailure(
+            f"command exited {completed.returncode}: {' '.join(values)}"
+        )
+    return completed
+
+
+def verify_host() -> None:
+    system = platform.system()
+    machine = platform.machine().lower()
+    supported = (system == "Linux" and machine == "x86_64") or (
+        system == "Darwin" and machine == "arm64"
+    )
+    if not supported:
+        raise FuzzFailure(
+            "roc-fuzz 0.2.0 supports Linux x86-64 and Apple Silicon macOS; "
+            f"this host reports {system} {machine}"
+        )
+
+
+def verify_pinned_roc(roc: str) -> None:
+    result = command([roc, "version"], capture=True)
+    actual = result.stdout.strip()
+    lines = (ROOT / ".roc-version").read_text(encoding="utf-8").splitlines()
+    if len(lines) != 1 or not lines[0].startswith("nightly-"):
+        raise FuzzFailure(".roc-version must contain exactly one Roc nightly tag")
+    pinned = lines[0]
+    revision = pinned.rsplit("-", 1)[-1]
+    if pinned not in actual and revision not in actual:
+        raise FuzzFailure(f"repository requires {pinned}, got {actual!r}")
+
+
+def selected_targets(name: str) -> list[Target]:
+    if name == "all":
+        return list(TARGETS.values())
+    return [TARGETS[name]]
+
+
+def validate_seed_entry(owner: str, value: object) -> tuple[str, bytes]:
+    if not isinstance(value, dict) or set(value) != {"name", "bytes_hex"}:
+        raise FuzzFailure(f"{owner} entries must contain exactly name and bytes_hex")
+    name = value["name"]
+    bytes_hex = value["bytes_hex"]
+    if not isinstance(name, str) or NAME_PATTERN.fullmatch(name) is None:
+        raise FuzzFailure(f"{owner} seed name must be lowercase kebab-case: {name!r}")
+    if not isinstance(bytes_hex, str):
+        raise FuzzFailure(f"{owner}/{name} bytes_hex must be a string")
+    try:
+        payload = bytes.fromhex(bytes_hex)
+    except ValueError as error:
+        raise FuzzFailure(f"{owner}/{name} has invalid hexadecimal bytes") from error
+    if payload.hex().upper() != bytes_hex:
+        raise FuzzFailure(
+            f"{owner}/{name} bytes_hex must be whitespace-free uppercase hexadecimal"
+        )
+    return name, payload
+
+
+def load_seeds() -> dict[str, list[tuple[str, bytes]]]:
+    try:
+        data = json.loads(SEED_PATH.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise FuzzFailure(f"unable to load {SEED_PATH}: {error}") from error
+    if not isinstance(data, dict) or set(data) != {"schema_version", "utf8", "grapheme"}:
+        raise FuzzFailure("fuzz seed manifest fields must be schema_version, utf8, grapheme")
+    if data["schema_version"] != 1:
+        raise FuzzFailure("unsupported fuzz seed manifest schema")
+
+    result: dict[str, list[tuple[str, bytes]]] = {}
+    for target_name in TARGETS:
+        entries = data[target_name]
+        if not isinstance(entries, list):
+            raise FuzzFailure(f"{target_name} seeds must be a list")
+        parsed = [
+            validate_seed_entry(target_name, value) for value in entries
+        ]
+        names = [name for name, _payload in parsed]
+        if len(names) != len(set(names)):
+            raise FuzzFailure(f"{target_name} seed names must be unique")
+        if target_name == "grapheme":
+            for name, payload in parsed:
+                try:
+                    payload.decode("utf-8")
+                except UnicodeDecodeError as error:
+                    raise FuzzFailure(f"grapheme/{name} must be valid UTF-8") from error
+        result[target_name] = parsed
+    return result
+
+
+def scalar_entropy(code_points: Sequence[int]) -> bytes:
+    result = bytearray()
+    for code_point in code_points:
+        if not (0 <= code_point <= 0x10FFFF) or 0xD800 <= code_point <= 0xDFFF:
+            raise FuzzFailure(f"U+{code_point:04X} is not a Unicode scalar")
+        rank = code_point if code_point <= 0xD7FF else code_point - 0x800
+        result.extend(rank.to_bytes(3, "little"))
+    return bytes(result)
+
+
+def target_seed_payloads(target: Target) -> list[tuple[str, bytes]]:
+    manifest = load_seeds()
+    if target.name == "utf8":
+        return manifest["utf8"]
+
+    seeds = [
+        (name, scalar_entropy([ord(character) for character in payload.decode("utf-8")]))
+        for name, payload in manifest["grapheme"]
+    ]
+    unicode_manifest = unicode_data.load_manifest()
+    for case in unicode_data.parse_grapheme_tests(unicode_manifest):
+        seeds.append((f"unicode17-{case.line}", scalar_entropy(case.code_points)))
+    return seeds
+
+
+def populate_corpus(target: Target, destination: Path, *, clean: bool) -> int:
+    if clean and destination.exists():
+        shutil.rmtree(destination)
+    destination.mkdir(parents=True, exist_ok=True)
+    unique: dict[str, bytes] = {}
+    for _name, payload in target_seed_payloads(target):
+        digest = hashlib.sha256(payload).hexdigest()
+        unique.setdefault(digest, payload)
+    for digest, payload in unique.items():
+        path = destination / f"seed-{digest[:20]}"
+        if not path.exists():
+            path.write_bytes(payload)
+    print(f"Prepared {len(unique)} unique {target.name} seeds in {destination}")
+    return len(unique)
+
+
+def build_target(roc: str, target: Target) -> Path:
+    verify_host()
+    verify_pinned_roc(roc)
+    BIN_ROOT.mkdir(parents=True, exist_ok=True)
+    command([roc, "fmt", "--check", FUZZ_ROOT / "FuzzSupport.roc", target.source])
+    command([roc, "check", target.source, "--no-cache"])
+    command(
+        [
+            roc,
+            "build",
+            "--fuzz",
+            target.source,
+            f"--output={target.binary}",
+            "--no-cache",
+        ]
+    )
+    return target.binary
+
+
+def smoke(roc: str, targets: Sequence[Target], runs: int) -> None:
+    if runs < 1:
+        raise FuzzFailure("smoke run count must be positive")
+    WORK_ROOT.mkdir(parents=True, exist_ok=True)
+    for target in targets:
+        binary = build_target(roc, target)
+        with tempfile.TemporaryDirectory(
+            prefix=f"smoke-{target.name}-", dir=WORK_ROOT
+        ) as temporary:
+            corpus = Path(temporary) / "corpus"
+            populate_corpus(target, corpus, clean=True)
+            command(
+                [
+                    binary,
+                    "run",
+                    corpus,
+                    f"--runs={runs}",
+                    "--seed=50",
+                    f"--max-input-size={target.max_input_size}",
+                    "--timeout=5",
+                    "--memory-limit=2048",
+                    "--print-final-stats",
+                ]
+            )
+
+
+def strip_separator(values: list[str]) -> list[str]:
+    return values[1:] if values[:1] == ["--"] else values
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--roc", default=os.environ.get("ROC", "roc"))
+    subparsers = parser.add_subparsers(dest="operation", required=True)
+
+    build_parser = subparsers.add_parser("build")
+    build_parser.add_argument("target", choices=("all", *TARGETS), default="all", nargs="?")
+
+    smoke_parser = subparsers.add_parser("smoke")
+    smoke_parser.add_argument("target", choices=("all", *TARGETS), default="all", nargs="?")
+    smoke_parser.add_argument("--runs", type=int, default=2000)
+
+    campaign_parser = subparsers.add_parser("campaign")
+    campaign_parser.add_argument("target", choices=tuple(TARGETS))
+    campaign_parser.add_argument("runner_args", nargs=argparse.REMAINDER)
+
+    reproduce_parser = subparsers.add_parser("reproduce")
+    reproduce_parser.add_argument("target", choices=tuple(TARGETS))
+    reproduce_parser.add_argument("artifact", type=Path)
+
+    minimize_parser = subparsers.add_parser("minimize")
+    minimize_parser.add_argument("target", choices=tuple(TARGETS))
+    minimize_parser.add_argument("input", type=Path)
+    minimize_parser.add_argument("output", type=Path)
+
+    args = parser.parse_args(argv)
+    try:
+        if args.operation == "build":
+            for target in selected_targets(args.target):
+                build_target(args.roc, target)
+        elif args.operation == "smoke":
+            smoke(args.roc, selected_targets(args.target), args.runs)
+        elif args.operation == "campaign":
+            target = TARGETS[args.target]
+            binary = build_target(args.roc, target)
+            corpus = PERSISTENT_CORPUS_ROOT / target.name
+            populate_corpus(target, corpus, clean=False)
+            command([binary, "run", corpus, *strip_separator(args.runner_args)])
+        elif args.operation == "reproduce":
+            target = TARGETS[args.target]
+            artifact = args.artifact.resolve()
+            payload = artifact.read_bytes()
+            print(f"raw-bytes={len(payload)} hex={payload.hex().upper()}")
+            binary = build_target(args.roc, target)
+            command([binary, "show", artifact])
+            command([binary, "replay", artifact])
+        elif args.operation == "minimize":
+            target = TARGETS[args.target]
+            binary = build_target(args.roc, target)
+            command([binary, "minimize", args.input.resolve(), args.output.resolve()])
+    except (FuzzFailure, OSError, subprocess.TimeoutExpired) as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/apps/allocation/README.md
+++ b/tests/apps/allocation/README.md
@@ -6,6 +6,12 @@ optimization mode, and integrated adaptive scanner. `.roc-version` is the sole
 compiler-version source of truth; the baseline does not duplicate it. This is
 not a cross-compiler performance threshold.
 
+The compiler pin required by the initial `roc-fuzz` integration changed the
+five-byte ASCII grapheme fixture from two allocation events to five. The other
+grapheme fixtures and every Word and Case exact baseline remained unchanged;
+the fixture records that measured compiler behavior rather than relaxing the
+allocation gate.
+
 The pinned compiler currently has a known ARC regression for the long SIMD
 grapheme collector, tracked in
 [roc-lang/roc#10635](https://github.com/roc-lang/roc/issues/10635). The baseline

--- a/tests/apps/allocation/baselines-linux-x64.json
+++ b/tests/apps/allocation/baselines-linux-x64.json
@@ -5,7 +5,7 @@
   "optimize": "speed",
   "fixtures": {
     "empty": 0,
-    "ascii": 2,
+    "ascii": 5,
     "combining": 1,
     "regional-indicator": 1,
     "emoji-zwj": 1,


### PR DESCRIPTION
## Summary

- add compiler-instrumented roc-fuzz targets for raw UTF-8 decoding and valid-text grapheme segmentation
- seed campaigns from Unicode 17 conformance data and historical Unicode regressions
- add a pinned-toolchain runner for builds, bounded smoke tests, persistent campaigns, reproduction, and minimization
- run the bounded smoke in CI on Linux x64 only

This establishes an extensible foundation for #50 rather than attempting to complete its full scope.

## Invariants exercised

- UTF-8 whole-input, byte-chunked, and stop/resume cursor executions agree
- emitted scalars re-encode to their exact source ranges
- successful and malformed outcomes agree with Str.from_utf8
- grapheme iterator, collector, materializer, and cursor APIs agree
- grapheme ranges form a lossless scalar-aligned partition
- materialized clusters are idempotent under segmentation
- terminal cursor states remain sealed
