### PR TITLE
Add word fuzz target

### DIFF
--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -26,9 +26,16 @@ scalar-chunk cursor results. Ranges must form a lossless scalar-aligned
 partition, and every materialized cluster must be idempotent under
 segmentation.
 
-The smoke runner limits UTF-8 artifacts to 512 bytes and grapheme artifacts to
-384 entropy bytes (at most 128 scalars). Each target is pure, bounded, and
-designed for libFuzzer's in-process execution model.
+`word` shares grapheme's valid-text domain and scalar generator. It compares
+`Word.ranges`, `Word.iter_ranges`, a whole-chunk `Word.Cursor`, and a
+scalar-chunk `Word.Cursor` against each other. Ranges must form a lossless
+scalar-aligned partition, `Word.slices` and `Word.owned` must agree with the
+materialized ranges, and every materialized word range must be idempotent
+under re-segmentation.
+
+The smoke runner limits UTF-8 artifacts to 512 bytes and grapheme and word
+artifacts to 384 entropy bytes each (at most 128 scalars). Each target is
+pure, bounded, and designed for libFuzzer's in-process execution model.
 
 ## Commands
 
@@ -55,10 +62,11 @@ the target's `show` function, and replays it in a fresh process.
 ## Seeds and regressions
 
 `seeds.json` stores reviewable hexadecimal sources. UTF-8 entries are copied
-unchanged. Grapheme entries must be valid UTF-8 and are converted to the
-target's stable three-byte scalar encoding. The runner also imports every
-sequence from the pinned Unicode 17 `GraphemeBreakTest.txt`, plus the historical
-crash inputs from issue #19 and the pirate-flag data-loss input from issue #22.
+unchanged. Grapheme and word entries must be valid UTF-8 and are converted to
+the shared stable three-byte scalar encoding. The runner also imports every
+sequence from the pinned Unicode 17 `GraphemeBreakTest.txt` and
+`WordBreakTest.txt`, plus the historical crash inputs from issue #19 and the
+pirate-flag data-loss input from issue #22.
 
 After finding a failure:
 

--- a/fuzz/seeds.json
+++ b/fuzz/seeds.json
@@ -34,5 +34,14 @@
     { "name": "issue-19-13", "bytes_hex": "EAB081E2808D24" },
     { "name": "issue-19-14", "bytes_hex": "F3A081AEEAB080E2808DE0A4BC" },
     { "name": "issue-22-pirate-flags", "bytes_hex": "F09F8FB4E2808DE298A0EFB88FF09F8F81F09F8E8CF09F9AA9F09F8FB3EFB88FE2808DF09F8C88" }
+  ],
+  "word": [
+    { "name": "ascii-sentence", "bytes_hex": "54686520717569636B20666F782072756E732E" },
+    { "name": "apostrophe-contraction", "bytes_hex": "646F6E2774" },
+    { "name": "numeric-punctuation", "bytes_hex": "332C3435362E3738" },
+    { "name": "katakana-run", "bytes_hex": "E382ABE382BFE382ABE3838A" },
+    { "name": "emoji-zwj-sequence", "bytes_hex": "F09F91A9E2808DF09F91A9E2808DF09F91A7" },
+    { "name": "regional-indicator-pair", "bytes_hex": "F09F87BAF09F87B8" },
+    { "name": "extend-zwj", "bytes_hex": "65CC81E2808D78" }
   ]
 }

--- a/fuzz/word.roc
+++ b/fuzz/word.roc
@@ -1,0 +1,117 @@
+app [target] {
+	fuzz: platform "https://github.com/lukewilliamboswell/roc-fuzz/releases/download/0.2.1/9Qpttb6LTgcMaVsSBLsnaiS2mDUrf6Bxa6dX9Rqwviz4.tar.zst",
+	unicode: "../package/main.roc",
+}
+
+import FuzzSupport
+import fuzz.Fuzz
+import unicode.ByteRange
+import unicode.Word
+
+test : List(U32) -> Fuzz.Outcome
+test = |code_points| {
+	parts = FuzzSupport.source_parts(code_points)
+	source = Str.join_with(parts, "")
+	collected = Word.ranges(source)
+	iterated = Word.iter_ranges(source).fold([], |ranges, range| ranges.append(range))
+	whole_cursor = cursor_ranges([source])
+	scalar_cursor = cursor_ranges([""].concat(parts).append(""))
+
+	if iterated != collected {
+		crash "Word.iter_ranges disagreed with Word.ranges"
+	}
+	if whole_cursor != collected {
+		crash "whole-chunk Word.Cursor disagreed with Word.ranges"
+	}
+	if scalar_cursor != collected {
+		crash "scalar-chunk Word.Cursor disagreed with Word.ranges"
+	}
+
+	validate_partition(source, collected)
+	expected_materialized = materialize(source, collected)
+	if Word.slices(source) != expected_materialized {
+		crash "Word.slices disagreed with range materialization"
+	}
+	if Word.owned(source) != expected_materialized {
+		crash "Word.owned disagreed with range materialization"
+	}
+	if Str.join_with(expected_materialized, "") != source {
+		crash "word materialization lost or changed source text"
+	}
+
+	for word in expected_materialized {
+		inner = Word.ranges(word)
+		if inner.len() != 1 {
+			crash "a word-boundary range was not idempotent under segmentation"
+		}
+		only = inner.get(0) ?? crash "one word range could not be read"
+		if ByteRange.start(only) != 0 or ByteRange.end(only) != word.count_utf8_bytes() {
+			crash "an idempotent word range did not cover its slice"
+		}
+	}
+
+	Fuzz.keep
+}
+
+cursor_ranges : List(Str) -> List(ByteRange)
+cursor_ranges = |chunks| {
+	var $cursor = Word.Cursor.init({})
+	var $ranges = []
+	for chunk in chunks {
+		pushed = Word.Cursor.push($cursor, chunk, $ranges, |ranges, range| ranges.append(range))
+		match pushed {
+			Failed(_) => crash "Word.Cursor.push failed for scalar-aligned input"
+			Pushed(next) => {
+				$cursor = next.cursor
+				$ranges = next.state
+			}
+		}
+	}
+	finished = Word.Cursor.finish($cursor, $ranges, |ranges, range| ranges.append(range))
+	match finished {
+		Failed(_) => crash "Word.Cursor.finish failed for an open cursor"
+		End(done) => {
+			match Word.Cursor.finish(done.cursor, [], |ranges, range| ranges.append(range)) {
+				Failed({ error: AlreadyFinished, .. }) => {}
+				_ => crash "Word.Cursor was not sealed after finish"
+			}
+			done.state
+		}
+	}
+}
+
+validate_partition : Str, List(ByteRange) -> {}
+validate_partition = |source, ranges| {
+	if source == "" and !ranges.is_empty() {
+		crash "empty text produced a word range"
+	}
+	if source != "" and ranges.is_empty() {
+		crash "nonempty text produced no word ranges"
+	}
+	var $next_start = 0
+	for range in ranges {
+		start = ByteRange.start(range)
+		end = ByteRange.end(range)
+		if start != $next_start or end <= start {
+			crash "word ranges were empty, overlapping, or discontinuous"
+		}
+		_ = ByteRange.slice(range, source) ?? crash "word range was not scalar-aligned and in bounds"
+		$next_start = end
+	}
+	if $next_start != source.count_utf8_bytes() {
+		crash "word ranges did not cover the complete source"
+	}
+	{}
+}
+
+materialize : Str, List(ByteRange) -> List(Str)
+materialize = |source, ranges| {
+	ranges.map(|range| ByteRange.slice(range, source) ?? crash "validated word range could not be sliced")
+}
+
+target = Fuzz.target_with({
+	name: "unicode-word",
+	generator: FuzzSupport.scalar_sequence,
+	test,
+	show: FuzzSupport.show_scalars,
+})

--- a/scripts/fuzz.py
+++ b/scripts/fuzz.py
@@ -48,6 +48,7 @@ class Target:
 TARGETS = {
     "utf8": Target("utf8", FUZZ_ROOT / "utf8.roc", 512),
     "grapheme": Target("grapheme", FUZZ_ROOT / "grapheme.roc", 384),
+    "word": Target("word", FUZZ_ROOT / "word.roc", 384),
 }
 
 
@@ -134,8 +135,8 @@ def load_seeds() -> dict[str, list[tuple[str, bytes]]]:
         data = json.loads(SEED_PATH.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError) as error:
         raise FuzzFailure(f"unable to load {SEED_PATH}: {error}") from error
-    if not isinstance(data, dict) or set(data) != {"schema_version", "utf8", "grapheme"}:
-        raise FuzzFailure("fuzz seed manifest fields must be schema_version, utf8, grapheme")
+    if not isinstance(data, dict) or set(data) != {"schema_version", "utf8", "grapheme", "word"}:
+        raise FuzzFailure("fuzz seed manifest fields must be schema_version, utf8, grapheme, word")
     if data["schema_version"] != 1:
         raise FuzzFailure("unsupported fuzz seed manifest schema")
 
@@ -150,12 +151,12 @@ def load_seeds() -> dict[str, list[tuple[str, bytes]]]:
         names = [name for name, _payload in parsed]
         if len(names) != len(set(names)):
             raise FuzzFailure(f"{target_name} seed names must be unique")
-        if target_name == "grapheme":
+        if target_name in ("grapheme", "word"):
             for name, payload in parsed:
                 try:
                     payload.decode("utf-8")
                 except UnicodeDecodeError as error:
-                    raise FuzzFailure(f"grapheme/{name} must be valid UTF-8") from error
+                    raise FuzzFailure(f"{target_name}/{name} must be valid UTF-8") from error
         result[target_name] = parsed
     return result
 
@@ -177,11 +178,15 @@ def target_seed_payloads(target: Target) -> list[tuple[str, bytes]]:
 
     seeds = [
         (name, scalar_entropy([ord(character) for character in payload.decode("utf-8")]))
-        for name, payload in manifest["grapheme"]
+        for name, payload in manifest[target.name]
     ]
     unicode_manifest = unicode_data.load_manifest()
-    for case in unicode_data.parse_grapheme_tests(unicode_manifest):
-        seeds.append((f"unicode17-{case.line}", scalar_entropy(case.code_points)))
+    if target.name == "grapheme":
+        for case in unicode_data.parse_grapheme_tests(unicode_manifest):
+            seeds.append((f"unicode17-{case.line}", scalar_entropy(case.code_points)))
+    elif target.name == "word":
+        for case in unicode_data.parse_word_break_tests(unicode_manifest):
+            seeds.append((f"unicode17-{case.line}", scalar_entropy(case.code_points)))
     return seeds
 
 


### PR DESCRIPTION
## Summary

Extends the coverage-guided fuzzing foundation (#50) with a new `word` target, `fuzz/word.roc`, exercising `Word.roc`'s UAX #29 default word-boundary API. `Word.roc` has the same `Cursor`/`ranges`/`iter_ranges`/`slices`/`owned` shape as `Grapheme.roc`, so the target mirrors `fuzz/grapheme.roc`'s structure and invariants directly.

- Compares `Word.ranges`, `Word.iter_ranges`, a whole-chunk `Word.Cursor` drive, and a scalar-chunk `Word.Cursor` drive against each other.
- Checks the ranges form a lossless, scalar-aligned, contiguous partition of the source.
- Checks `Word.slices`/`Word.owned` agree with the materialized ranges and round-trip losslessly.
- Checks every materialized word-boundary range is idempotent under re-segmentation (no internal boundary).
- Registers `word` in `scripts/fuzz.py`'s `TARGETS`, widens the seed-manifest schema, and seeds from named UAX #29 edge cases (contractions, numeric punctuation, Katakana, emoji ZWJ, regional-indicator pairs, extend+ZWJ) plus every case in the pinned Unicode 17 `WordBreakTest.txt` via the existing `parse_word_break_tests` helper.
- Documents the new target in `fuzz/README.md`.

`LineBreak.roc` (the other "priority 1" item in #50) is materially more complex (profiles, boundary vs. opportunity streams, an ASCII fast-path chunk cursor) and is left for a follow-up.

## Test plan

- [x] `scripts/fuzz.py build word` — formats, type-checks, and builds cleanly.
- [x] `scripts/fuzz.py smoke word` — 2,000 bounded mutations, no crashes.
- [x] `scripts/fuzz.py smoke` (all targets) — `utf8`/`grapheme`/`word` all pass, confirming CI's `fuzz-smoke` job is unaffected.
- [x] `scripts/fuzz.py campaign word -- --time=1800` — 30-minute local campaign, 7,236,189 executions (~4017 exec/s), no crashes found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)