### PR TITLE
Add line-break fuzz target

### DIFF
--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -33,9 +33,21 @@ scalar-aligned partition, `Word.slices` and `Word.owned` must agree with the
 materialized ranges, and every materialized word range must be idempotent
 under re-segmentation.
 
-The smoke runner limits UTF-8 artifacts to 512 bytes and grapheme and word
-artifacts to 384 entropy bytes each (at most 128 scalars). Each target is
-pure, bounded, and designed for libFuzzer's in-process execution model.
+`line-break` also shares the valid-text domain and scalar generator, exercised
+under the exact Unicode-default profile only (tailored-profile campaigns
+remain follow-up work). It compares the exhaustive boundary stream
+(`LineBreak.boundaries` / `iter_boundaries`), the opportunity stream
+(`LineBreak.opportunities` / `iter_opportunities`), and a chunked
+`LineBreak.Cursor` drive (whole-input and one-scalar-at-a-time). Opportunities
+must equal the non-Prohibited subset of boundaries; boundary positions must be
+ordered, scalar-aligned, start with the LB2 prohibited start-of-text marker,
+end with the LB3 mandatory end-of-text break, and tile the source into a
+lossless partition.
+
+The smoke runner limits UTF-8 artifacts to 512 bytes and grapheme, word, and
+line-break artifacts to 384 entropy bytes each (at most 128 scalars). Each
+target is pure, bounded, and designed for libFuzzer's in-process execution
+model.
 
 ## Commands
 
@@ -62,11 +74,11 @@ the target's `show` function, and replays it in a fresh process.
 ## Seeds and regressions
 
 `seeds.json` stores reviewable hexadecimal sources. UTF-8 entries are copied
-unchanged. Grapheme and word entries must be valid UTF-8 and are converted to
-the shared stable three-byte scalar encoding. The runner also imports every
-sequence from the pinned Unicode 17 `GraphemeBreakTest.txt` and
-`WordBreakTest.txt`, plus the historical crash inputs from issue #19 and the
-pirate-flag data-loss input from issue #22.
+unchanged. Grapheme, word, and line-break entries must be valid UTF-8 and are
+converted to the shared stable three-byte scalar encoding. The runner also
+imports every sequence from the pinned Unicode 17 `GraphemeBreakTest.txt`,
+`WordBreakTest.txt`, and `LineBreakTest.txt`, plus the historical crash inputs
+from issue #19 and the pirate-flag data-loss input from issue #22.
 
 After finding a failure:
 
@@ -83,7 +95,7 @@ legitimately change those measurements.
 
 ## Deferred work
 
-Line breaking, property scans, Script itemization, bidi, structured chunk
-plans and limits, Unicode-version-matched differential oracles, corpus
-reduction automation, artifact upload, and resource-guarded long scheduled
-campaigns remain follow-up work under issue #50.
+Line-break tailoring profiles, property scans, Script itemization, bidi,
+structured chunk plans and limits, Unicode-version-matched differential
+oracles, corpus reduction automation, artifact upload, and resource-guarded
+long scheduled campaigns remain follow-up work under issue #50.

--- a/fuzz/line-break.roc
+++ b/fuzz/line-break.roc
@@ -1,0 +1,175 @@
+app [target] {
+	fuzz: platform "https://github.com/lukewilliamboswell/roc-fuzz/releases/download/0.2.1/9Qpttb6LTgcMaVsSBLsnaiS2mDUrf6Bxa6dX9Rqwviz4.tar.zst",
+	unicode: "../package/main.roc",
+}
+
+import FuzzSupport
+import fuzz.Fuzz
+import unicode.ByteRange
+import unicode.LineBreak
+import unicode.TextPosition
+
+test : List(U32) -> Fuzz.Outcome
+test = |code_points| {
+	parts = FuzzSupport.source_parts(code_points)
+	source = Str.join_with(parts, "")
+
+	boundaries = LineBreak.boundaries(source)
+	iterated_boundaries = LineBreak.iter_boundaries(source).fold([], |items, item| items.append(item))
+	opportunities = LineBreak.opportunities(source)
+	iterated_opportunities = LineBreak.iter_opportunities(source).fold([], |items, item| items.append(item))
+	whole_cursor = cursor_opportunities([source])
+	scalar_cursor = cursor_opportunities([""].concat(parts).append(""))
+
+	if iterated_boundaries != boundaries {
+		crash "LineBreak.iter_boundaries disagreed with LineBreak.boundaries"
+	}
+	if iterated_opportunities != opportunities {
+		crash "LineBreak.iter_opportunities disagreed with LineBreak.opportunities"
+	}
+	if whole_cursor != opportunities {
+		crash "whole-chunk LineBreak.Cursor disagreed with LineBreak.opportunities"
+	}
+	if scalar_cursor != opportunities {
+		crash "scalar-chunk LineBreak.Cursor disagreed with LineBreak.opportunities"
+	}
+	if boundaries_as_opportunities(boundaries) != opportunities {
+		crash "opportunities were not the non-Prohibited subset of boundaries"
+	}
+
+	validate_boundaries(source, boundaries, code_points.len())
+
+	Fuzz.keep
+}
+
+cursor_opportunities : List(Str) -> List(LineBreak.BreakOpportunity)
+cursor_opportunities = |chunks| {
+	var $cursor = LineBreak.Cursor.init({})
+	var $items = []
+	for chunk in chunks {
+		pushed = LineBreak.Cursor.push($cursor, chunk, $items, |items, item| items.append(item))
+		match pushed {
+			Failed(_) => crash "LineBreak.Cursor.push failed for scalar-aligned input"
+			Pushed(next) => {
+				$cursor = next.cursor
+				$items = next.state
+			}
+		}
+	}
+	finished = LineBreak.Cursor.finish($cursor, $items, |items, item| items.append(item))
+	match finished {
+		Failed(_) => crash "LineBreak.Cursor.finish failed for an open cursor"
+		End(done) => {
+			match LineBreak.Cursor.finish(done.cursor, [], |items, item| items.append(item)) {
+				Failed({ error: AlreadyFinished, .. }) => {}
+				_ => crash "LineBreak.Cursor was not sealed after finish"
+			}
+			done.state
+		}
+	}
+}
+
+## The exhaustive boundary stream reports Prohibited, Allowed, and Mandatory
+## decisions; the opportunity stream reports only the non-Prohibited subset
+## with the same positions and authorities.
+boundaries_as_opportunities : List(LineBreak.BreakBoundary) -> List(LineBreak.BreakOpportunity)
+boundaries_as_opportunities = |boundaries| {
+	var $result = []
+	for boundary in boundaries {
+		match boundary.decision {
+			Prohibited => {}
+			Mandatory => {
+				$result = $result.append({ at: boundary.at, decision: Mandatory, authority: boundary.authority })
+			}
+			Allowed => {
+				$result = $result.append({ at: boundary.at, decision: Allowed, authority: boundary.authority })
+			}
+		}
+	}
+	$result
+}
+
+validate_boundaries : Str, List(LineBreak.BreakBoundary), U64 -> {}
+validate_boundaries = |source, boundaries, scalar_count| {
+	total_bytes = source.count_utf8_bytes()
+
+	first = boundaries.get(0) ?? crash "LineBreak.boundaries produced no entries"
+	if first.decision != Prohibited or first.authority != NonTailorable or TextPosition.byte_offset(first.at) != 0 or TextPosition.scalar_offset(first.at) != 0 {
+		crash "line-break boundaries did not start with the LB2 prohibited start-of-text marker"
+	}
+
+	last = boundaries.last() ?? crash "LineBreak.boundaries produced no entries"
+	if last.decision != Mandatory or last.authority != NonTailorable or TextPosition.byte_offset(last.at) != total_bytes or TextPosition.scalar_offset(last.at) != scalar_count {
+		crash "line-break boundaries did not end with the LB3 mandatory end-of-text break"
+	}
+
+	var $previous_byte = 0
+	var $previous_scalar = 0
+	for boundary in boundaries {
+		byte_offset = TextPosition.byte_offset(boundary.at)
+		scalar_offset = TextPosition.scalar_offset(boundary.at)
+		if byte_offset < $previous_byte or scalar_offset < $previous_scalar {
+			crash "line-break boundary offsets went backwards"
+		}
+		if byte_offset > total_bytes or scalar_offset > scalar_count {
+			crash "line-break boundary offsets exceeded the source"
+		}
+		$previous_byte = byte_offset
+		$previous_scalar = scalar_offset
+	}
+
+	if source == "" {
+		if boundaries.len() != 2 {
+			crash "empty source did not produce exactly the LB2/LB3 boundary pair"
+		}
+	} else {
+		validate_partition(source, boundary_ranges(boundaries))
+	}
+	{}
+}
+
+## Consecutive boundary positions bound the scalar-aligned spans between them.
+boundary_ranges : List(LineBreak.BreakBoundary) -> List(ByteRange)
+boundary_ranges = |boundaries| {
+	var $ranges = []
+	var $previous = None
+	for boundary in boundaries {
+		match $previous {
+			None => {}
+			Some(previous_byte) => {
+				range = ByteRange.from_bounds(previous_byte, TextPosition.byte_offset(boundary.at)) ?? crash "line-break boundaries were not monotonic"
+				$ranges = $ranges.append(range)
+			}
+		}
+		$previous = Some(TextPosition.byte_offset(boundary.at))
+	}
+	$ranges
+}
+
+validate_partition : Str, List(ByteRange) -> {}
+validate_partition = |source, ranges| {
+	if ranges.is_empty() {
+		crash "nonempty text produced no line-break spans"
+	}
+	var $next_start = 0
+	for range in ranges {
+		start = ByteRange.start(range)
+		end = ByteRange.end(range)
+		if start != $next_start or end <= start {
+			crash "line-break spans were empty, overlapping, or discontinuous"
+		}
+		_ = ByteRange.slice(range, source) ?? crash "line-break span was not scalar-aligned and in bounds"
+		$next_start = end
+	}
+	if $next_start != source.count_utf8_bytes() {
+		crash "line-break spans did not cover the complete source"
+	}
+	{}
+}
+
+target = Fuzz.target_with({
+	name: "unicode-line-break",
+	generator: FuzzSupport.scalar_sequence,
+	test,
+	show: FuzzSupport.show_scalars,
+})

--- a/fuzz/seeds.json
+++ b/fuzz/seeds.json
@@ -43,5 +43,14 @@
     { "name": "emoji-zwj-sequence", "bytes_hex": "F09F91A9E2808DF09F91A9E2808DF09F91A7" },
     { "name": "regional-indicator-pair", "bytes_hex": "F09F87BAF09F87B8" },
     { "name": "extend-zwj", "bytes_hex": "65CC81E2808D78" }
+  ],
+  "line-break": [
+    { "name": "cjk-ideograph-run", "bytes_hex": "E4B8ADE69687E5AD97E7ACA6E4B8B2" },
+    { "name": "hyphenated-compound", "bytes_hex": "77656C6C2D6B6E6F776E" },
+    { "name": "non-breaking-space-glue", "bytes_hex": "313030C2A06B6D" },
+    { "name": "mandatory-newline", "bytes_hex": "6C696E65206F6E650A6C696E652074776F" },
+    { "name": "parenthetical-quote", "bytes_hex": "222868656C6C6F2922" },
+    { "name": "emoji-zwj-sequence", "bytes_hex": "F09F91A9E2808DF09F91A9E2808DF09F91A7" },
+    { "name": "numeric-grouping", "bytes_hex": "312C3233342C353637" }
   ]
 }

--- a/scripts/fuzz.py
+++ b/scripts/fuzz.py
@@ -49,6 +49,7 @@ TARGETS = {
     "utf8": Target("utf8", FUZZ_ROOT / "utf8.roc", 512),
     "grapheme": Target("grapheme", FUZZ_ROOT / "grapheme.roc", 384),
     "word": Target("word", FUZZ_ROOT / "word.roc", 384),
+    "line-break": Target("line-break", FUZZ_ROOT / "line-break.roc", 384),
 }
 
 
@@ -135,8 +136,16 @@ def load_seeds() -> dict[str, list[tuple[str, bytes]]]:
         data = json.loads(SEED_PATH.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError) as error:
         raise FuzzFailure(f"unable to load {SEED_PATH}: {error}") from error
-    if not isinstance(data, dict) or set(data) != {"schema_version", "utf8", "grapheme", "word"}:
-        raise FuzzFailure("fuzz seed manifest fields must be schema_version, utf8, grapheme, word")
+    if not isinstance(data, dict) or set(data) != {
+        "schema_version",
+        "utf8",
+        "grapheme",
+        "word",
+        "line-break",
+    }:
+        raise FuzzFailure(
+            "fuzz seed manifest fields must be schema_version, utf8, grapheme, word, line-break"
+        )
     if data["schema_version"] != 1:
         raise FuzzFailure("unsupported fuzz seed manifest schema")
 
@@ -151,7 +160,7 @@ def load_seeds() -> dict[str, list[tuple[str, bytes]]]:
         names = [name for name, _payload in parsed]
         if len(names) != len(set(names)):
             raise FuzzFailure(f"{target_name} seed names must be unique")
-        if target_name in ("grapheme", "word"):
+        if target_name in ("grapheme", "word", "line-break"):
             for name, payload in parsed:
                 try:
                     payload.decode("utf-8")
@@ -186,6 +195,9 @@ def target_seed_payloads(target: Target) -> list[tuple[str, bytes]]:
             seeds.append((f"unicode17-{case.line}", scalar_entropy(case.code_points)))
     elif target.name == "word":
         for case in unicode_data.parse_word_break_tests(unicode_manifest):
+            seeds.append((f"unicode17-{case.line}", scalar_entropy(case.code_points)))
+    elif target.name == "line-break":
+        for case in unicode_data.parse_line_break_tests(unicode_manifest):
             seeds.append((f"unicode17-{case.line}", scalar_entropy(case.code_points)))
     return seeds
 


### PR DESCRIPTION
## Summary

Stacked on #58. Extends the coverage-guided fuzzing foundation (#50) with a `line-break` target, `fuzz/line-break.roc`, exercising `LineBreak.roc`'s UAX #14 default-profile API — the other half of issue #50's "line and word boundaries" priority item.

- Compares the exhaustive boundary stream (`LineBreak.boundaries` / `iter_boundaries`) against the opportunity stream (`LineBreak.opportunities` / `iter_opportunities`) and whole/scalar-chunk `LineBreak.Cursor` drives.
- Checks opportunities are exactly the non-Prohibited subset of boundaries.
- Checks boundary positions are ordered and scalar-aligned, start with the LB2 prohibited start-of-text marker, end with the LB3 mandatory end-of-text break, and tile the source into a lossless partition (reusing the same partition-validation shape as the `grapheme`/`word` targets).
- Registers `line-break` in `scripts/fuzz.py`'s `TARGETS`, widens the seed-manifest schema, and seeds from named UAX #14 edge cases (CJK runs, hyphenation, NBSP glue, mandatory newlines, paired punctuation, emoji ZWJ, numeric grouping) plus every case in the pinned Unicode 17 `LineBreakTest.txt` via the existing `parse_line_break_tests` helper.
- Documents the new target in `fuzz/README.md`.

Only the exact Unicode-default profile is exercised; `LineBreak.PreserveGraphemes` tailoring is noted as follow-up work in the README, consistent with keeping this target narrowly scoped like `utf8`/`grapheme`/`word`.

## Test plan

- [x] `scripts/fuzz.py build line-break` — formats, type-checks, and builds cleanly.
- [x] `scripts/fuzz.py smoke line-break` — clean run over the 19k-entry seed corpus (mostly `LineBreakTest.txt` cases), no crashes.
- [x] `scripts/fuzz.py smoke` (all targets) — `utf8`/`grapheme`/`word`/`line-break` all pass, confirming CI's `fuzz-smoke` job is unaffected.
- [x] `scripts/fuzz.py campaign line-break -- --time=1800` — 30-minute local campaign, 5,056,063 executions (~2807 exec/s), no crashes found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)