### PR TITLE
Add case fuzz target

### DIFF
--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -44,10 +44,22 @@ ordered, scalar-aligned, start with the LB2 prohibited start-of-text marker,
 end with the LB3 mandatory end-of-text break, and tile the source into a
 lossless partition.
 
-The smoke runner limits UTF-8 artifacts to 512 bytes and grapheme, word, and
-line-break artifacts to 384 entropy bytes each (at most 128 scalars). Each
-target is pure, bounded, and designed for libFuzzer's in-process execution
-model.
+`case` shares the valid-text domain and scalar generator too, exercising
+`Case.roc` under its default mapping profile (`to_lower`/`to_upper`/`to_title`)
+and its full fold profile (`fold`), all under `Case.unlimited_limits`
+(explicit profile/limit variation remains follow-up work, matching
+`line-break`'s default-profile-only scope). Each result's input facts must
+form a nonempty, scalar-aligned, contiguous partition of the source; its
+output facts must tile the result text contiguously (an empty output span is
+allowed only for a `Removed` fact); an `Unchanged` fact's input and output
+slices must match exactly. `fold` and `to_lower` must be idempotent on their
+own output, and a zero input-byte budget must atomically reject any nonempty
+source with `LimitExceeded`.
+
+The smoke runner limits UTF-8 artifacts to 512 bytes and grapheme, word,
+line-break, and case artifacts to 384 entropy bytes each (at most 128
+scalars). Each target is pure, bounded, and designed for libFuzzer's
+in-process execution model.
 
 ## Commands
 
@@ -74,11 +86,12 @@ the target's `show` function, and replays it in a fresh process.
 ## Seeds and regressions
 
 `seeds.json` stores reviewable hexadecimal sources. UTF-8 entries are copied
-unchanged. Grapheme, word, and line-break entries must be valid UTF-8 and are
-converted to the shared stable three-byte scalar encoding. The runner also
-imports every sequence from the pinned Unicode 17 `GraphemeBreakTest.txt`,
-`WordBreakTest.txt`, and `LineBreakTest.txt`, plus the historical crash inputs
-from issue #19 and the pirate-flag data-loss input from issue #22.
+unchanged. Grapheme, word, line-break, and case entries must be valid UTF-8
+and are converted to the shared stable three-byte scalar encoding. The runner
+also imports every sequence from the pinned Unicode 17 `GraphemeBreakTest.txt`,
+`WordBreakTest.txt`, and `LineBreakTest.txt`, every `SpecialCasing.txt` and
+`CaseFolding.txt` source scalar, plus the historical crash inputs from issue
+#19 and the pirate-flag data-loss input from issue #22.
 
 After finding a failure:
 
@@ -95,7 +108,8 @@ legitimately change those measurements.
 
 ## Deferred work
 
-Line-break tailoring profiles, property scans, Script itemization, bidi,
+Line-break tailoring profiles, case-mapping Turkic/Lithuanian profiles and
+explicit resource limits, property scans, Script itemization, bidi,
 structured chunk plans and limits, Unicode-version-matched differential
 oracles, corpus reduction automation, artifact upload, and resource-guarded
 long scheduled campaigns remain follow-up work under issue #50.

--- a/fuzz/case.roc
+++ b/fuzz/case.roc
@@ -1,0 +1,140 @@
+app [target] {
+	fuzz: platform "https://github.com/lukewilliamboswell/roc-fuzz/releases/download/0.2.1/9Qpttb6LTgcMaVsSBLsnaiS2mDUrf6Bxa6dX9Rqwviz4.tar.zst",
+	unicode: "../package/main.roc",
+}
+
+import FuzzSupport
+import fuzz.Fuzz
+import unicode.ByteRange
+import unicode.Case
+import unicode.TextRange
+
+test : List(U32) -> Fuzz.Outcome
+test = |code_points| {
+	parts = FuzzSupport.source_parts(code_points)
+	source = Str.join_with(parts, "")
+
+	lower = Case.to_lower(source, Case.unicode_default, Case.unlimited_limits) ?? crash "Case.to_lower failed under unlimited limits"
+	upper = Case.to_upper(source, Case.unicode_default, Case.unlimited_limits) ?? crash "Case.to_upper failed under unlimited limits"
+	title = Case.to_title(source, Case.unicode_default, Case.unlimited_limits) ?? crash "Case.to_title failed under unlimited limits"
+	folded = Case.fold(source, Case.full, Case.unlimited_limits) ?? crash "Case.fold failed under unlimited limits"
+
+	validate_result(source, lower)
+	validate_result(source, upper)
+	validate_result(source, title)
+	validate_result(source, folded)
+
+	refolded = Case.fold(Case.result_text(folded), Case.full, Case.unlimited_limits) ?? crash "Case.fold failed on its own output"
+	if Case.result_text(refolded) != Case.result_text(folded) {
+		crash "Case.fold was not idempotent on its own output"
+	}
+
+	relowered = Case.to_lower(Case.result_text(lower), Case.unicode_default, Case.unlimited_limits) ?? crash "Case.to_lower failed on its own output"
+	if Case.result_text(relowered) != Case.result_text(lower) {
+		crash "Case.to_lower was not idempotent on its own output"
+	}
+
+	check_zero_budget_limit_failure(source)
+
+	Fuzz.keep
+}
+
+## A zero input-byte budget must reject any nonempty source atomically: no
+## partial text or facts, only a `LimitExceeded` error.
+check_zero_budget_limit_failure : Str -> {}
+check_zero_budget_limit_failure = |source| {
+	tiny_limits = Case.limits(0, U64.highest, U64.highest, U64.highest, U64.highest)
+	match Case.to_lower(source, Case.unicode_default, tiny_limits) {
+		Ok(_) => if source != "" {
+			crash "a zero input-byte budget accepted nonempty input"
+		}
+		Err(error) => match Case.error_kind(error) {
+			LimitExceeded => {}
+			_ => crash "a zero input-byte budget failed with something other than LimitExceeded"
+		}
+	}
+	{}
+}
+
+validate_result : Str, Case.Result -> {}
+validate_result = |source, result| {
+	text = Case.result_text(result)
+	facts = Case.result_facts(result)
+
+	input_ranges = facts.map(|fact| TextRange.byte_range(Case.fact_input(fact)))
+	output_ranges = facts.map(|fact| TextRange.byte_range(Case.fact_output(fact)))
+
+	validate_source_partition(source, input_ranges)
+	validate_result_partition(text, output_ranges)
+
+	for fact in facts {
+		input_range = TextRange.byte_range(Case.fact_input(fact))
+		output_range = TextRange.byte_range(Case.fact_output(fact))
+		input_slice = ByteRange.slice(input_range, source) ?? crash "a case fact input range was not scalar-aligned and in bounds"
+		output_slice = ByteRange.slice(output_range, text) ?? crash "a case fact output range was not scalar-aligned and in bounds"
+		match Case.fact_shape(fact) {
+			Removed => if !ByteRange.is_empty(output_range) {
+				crash "a Removed case fact produced a nonempty output range"
+			}
+			Unchanged => if input_slice != output_slice {
+				crash "an Unchanged case fact changed its source text"
+			}
+			Simple => {}
+			Expanded => {}
+		}
+	}
+	{}
+}
+
+## One fact per source scalar: ranges are nonempty, scalar-aligned, contiguous,
+## and cover the complete source exactly.
+validate_source_partition : Str, List(ByteRange) -> {}
+validate_source_partition = |source, ranges| {
+	if source == "" and !ranges.is_empty() {
+		crash "empty source produced a case fact"
+	}
+	if source != "" and ranges.is_empty() {
+		crash "nonempty source produced no case facts"
+	}
+	var $next_start = 0
+	for range in ranges {
+		start = ByteRange.start(range)
+		end = ByteRange.end(range)
+		if start != $next_start or end <= start {
+			crash "case input ranges were empty, overlapping, or discontinuous"
+		}
+		_ = ByteRange.slice(range, source) ?? crash "case input range was not scalar-aligned and in bounds"
+		$next_start = end
+	}
+	if $next_start != source.count_utf8_bytes() {
+		crash "case input ranges did not cover the complete source"
+	}
+	{}
+}
+
+## Output ranges may be empty (a `Removed` fact), but must stay contiguous and
+## cover the complete result text exactly.
+validate_result_partition : Str, List(ByteRange) -> {}
+validate_result_partition = |text, ranges| {
+	var $next_start = 0
+	for range in ranges {
+		start = ByteRange.start(range)
+		end = ByteRange.end(range)
+		if start != $next_start or end < start {
+			crash "case output ranges were overlapping or discontinuous"
+		}
+		_ = ByteRange.slice(range, text) ?? crash "case output range was not scalar-aligned and in bounds"
+		$next_start = end
+	}
+	if $next_start != text.count_utf8_bytes() {
+		crash "case output ranges did not cover the complete result text"
+	}
+	{}
+}
+
+target = Fuzz.target_with({
+	name: "unicode-case",
+	generator: FuzzSupport.scalar_sequence,
+	test,
+	show: FuzzSupport.show_scalars,
+})

--- a/fuzz/seeds.json
+++ b/fuzz/seeds.json
@@ -52,5 +52,13 @@
     { "name": "parenthetical-quote", "bytes_hex": "222868656C6C6F2922" },
     { "name": "emoji-zwj-sequence", "bytes_hex": "F09F91A9E2808DF09F91A9E2808DF09F91A7" },
     { "name": "numeric-grouping", "bytes_hex": "312C3233342C353637" }
+  ],
+  "case": [
+    { "name": "german-sharp-s", "bytes_hex": "73747261C39F65" },
+    { "name": "turkish-dotted-capital-i", "bytes_hex": "C4B07374616E62756C" },
+    { "name": "greek-final-sigma-word", "bytes_hex": "CE9FCEA3" },
+    { "name": "kelvin-sign", "bytes_hex": "E284AA" },
+    { "name": "ligature-ffi", "bytes_hex": "EFAC83" },
+    { "name": "combining-dot-above", "bytes_hex": "69CC87" }
   ]
 }

--- a/scripts/fuzz.py
+++ b/scripts/fuzz.py
@@ -50,6 +50,7 @@ TARGETS = {
     "grapheme": Target("grapheme", FUZZ_ROOT / "grapheme.roc", 384),
     "word": Target("word", FUZZ_ROOT / "word.roc", 384),
     "line-break": Target("line-break", FUZZ_ROOT / "line-break.roc", 384),
+    "case": Target("case", FUZZ_ROOT / "case.roc", 384),
 }
 
 
@@ -142,9 +143,11 @@ def load_seeds() -> dict[str, list[tuple[str, bytes]]]:
         "grapheme",
         "word",
         "line-break",
+        "case",
     }:
         raise FuzzFailure(
-            "fuzz seed manifest fields must be schema_version, utf8, grapheme, word, line-break"
+            "fuzz seed manifest fields must be schema_version, utf8, grapheme, word, "
+            "line-break, case"
         )
     if data["schema_version"] != 1:
         raise FuzzFailure("unsupported fuzz seed manifest schema")
@@ -160,7 +163,7 @@ def load_seeds() -> dict[str, list[tuple[str, bytes]]]:
         names = [name for name, _payload in parsed]
         if len(names) != len(set(names)):
             raise FuzzFailure(f"{target_name} seed names must be unique")
-        if target_name in ("grapheme", "word", "line-break"):
+        if target_name in ("grapheme", "word", "line-break", "case"):
             for name, payload in parsed:
                 try:
                     payload.decode("utf-8")
@@ -199,6 +202,13 @@ def target_seed_payloads(target: Target) -> list[tuple[str, bytes]]:
     elif target.name == "line-break":
         for case in unicode_data.parse_line_break_tests(unicode_manifest):
             seeds.append((f"unicode17-{case.line}", scalar_entropy(case.code_points)))
+    elif target.name == "case":
+        canonical = unicode_data.load_canonical_properties(unicode_manifest)
+        case_data = unicode_data.load_case_data(unicode_manifest, canonical)
+        for entry in case_data.special:
+            seeds.append((f"special-casing-{entry.line}", scalar_entropy([entry.source])))
+        for entry in case_data.folding:
+            seeds.append((f"case-folding-{entry.line}", scalar_entropy([entry.source])))
     return seeds
 
 


### PR DESCRIPTION
## Summary

Extends the coverage-guided fuzzing foundation (#50) with a `case` target, `fuzz/case.roc`, exercising `Case.roc`'s Unicode 17 case-mapping and folding API — issue #50's priority 2 item. (Follows #58 word and #59 line-break, both now merged.)

- Exercises `to_lower`/`to_upper`/`to_title` under the default (`UnicodeDefault`) mapping profile and `fold` under the full fold profile, all under `Case.unlimited_limits`.
- Checks each result's input facts form a nonempty, scalar-aligned, contiguous partition of the source ("one source fact per input scalar").
- Checks output facts tile the result text contiguously; an empty output span is only allowed for a `Removed` fact.
- Checks an `Unchanged` fact's input and output slices match exactly.
- Checks `fold` and `to_lower` are idempotent on their own output.
- Checks a zero input-byte budget atomically rejects any nonempty source with `LimitExceeded` (no partial result).
- Registers `case` in `scripts/fuzz.py`'s `TARGETS`, widens the seed-manifest schema, and seeds from named edge cases (sharp s, Turkish dotted I, Greek final sigma, Kelvin sign, ligature, combining dot above) plus every `SpecialCasing.txt` and `CaseFolding.txt` source scalar via the existing `load_case_data`/`load_canonical_properties` helpers.
- Documents the new target in `fuzz/README.md`.

Turkic/Lithuanian mapping profiles and explicit non-trivial resource limits are left as follow-up work in the README, matching how `line-break` scoped itself to the default profile only.

## Test plan

- [x] `scripts/fuzz.py build case` — formats, type-checks, and builds cleanly.
- [x] `scripts/fuzz.py smoke case` — clean run over the ~1.7k-entry seed corpus (special-casing + case-folding scalars), no crashes.
- [x] `scripts/fuzz.py smoke` (all targets) — `utf8`/`grapheme`/`word`/`line-break`/`case` all pass, confirming CI's `fuzz-smoke` job is unaffected.
- [x] `scripts/fuzz.py campaign case -- --time=1800` — 30-minute local campaign, 2,254,558 executions (~1251 exec/s), no crashes found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)