### PR TITLE
Add property fuzz target

### DIFF
--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -56,9 +56,33 @@ slices must match exactly. `fold` and `to_lower` must be idempotent on their
 own output, and a zero input-byte budget must atomically reject any nonempty
 source with `LimitExceeded`.
 
+`property` shares the valid-text domain and scalar generator too, exercising
+`GeneralCategory` and `CanonicalCombiningClass` (`EastAsianWidth` is excluded;
+see below). `Property.iter` must agree with `Property.fold` on the decoded
+scalar sequence; each scalar's direct query must agree with the composite
+`Property.Row` view; `fold_runs` must agree with `iter_runs`; runs must form a
+lossless, scalar-aligned, contiguous partition where adjacent runs never
+share a value (maximality) and every scalar inside a run carries that run's
+directly-queried value; and every short/long/generated alias must round-trip
+through `parse` back to the same value. The scalar generator's full-range
+coverage exercises table boundaries and unassigned/private-use scalars
+without any special-casing.
+
+`EastAsianWidth` is deliberately excluded from `property`: its generated
+lookup (`InternalEAW.roc`) is a single very large if/else boolean-OR chain
+(unlike `GeneralCategory`/`CanonicalCombiningClass`, which use compact
+page-table lookups), and compiling any call into it reproducibly overflows the
+compiler's stack under both `roc check` and an ordinary basic-cli `roc build`.
+This is tracked upstream in [roc-lang/roc#10755][roc-10755]. It is a
+compiler/data-representation limitation, not a target design choice;
+regenerating `InternalEAW.roc` with a page-table representation (as issue #50
+or a follow-up) would remove the blocker.
+
+[roc-10755]: https://github.com/roc-lang/roc/issues/10755
+
 The smoke runner limits UTF-8 artifacts to 512 bytes and grapheme, word,
-line-break, and case artifacts to 384 entropy bytes each (at most 128
-scalars). Each target is pure, bounded, and designed for libFuzzer's
+line-break, case, and property artifacts to 384 entropy bytes each (at most
+128 scalars). Each target is pure, bounded, and designed for libFuzzer's
 in-process execution model.
 
 ## Commands
@@ -86,12 +110,15 @@ the target's `show` function, and replays it in a fresh process.
 ## Seeds and regressions
 
 `seeds.json` stores reviewable hexadecimal sources. UTF-8 entries are copied
-unchanged. Grapheme, word, line-break, and case entries must be valid UTF-8
-and are converted to the shared stable three-byte scalar encoding. The runner
-also imports every sequence from the pinned Unicode 17 `GraphemeBreakTest.txt`,
-`WordBreakTest.txt`, and `LineBreakTest.txt`, every `SpecialCasing.txt` and
-`CaseFolding.txt` source scalar, plus the historical crash inputs from issue
-#19 and the pirate-flag data-loss input from issue #22.
+unchanged. Grapheme, word, line-break, case, and property entries must be
+valid UTF-8 and are converted to the shared stable three-byte scalar
+encoding. The runner also imports every sequence from the pinned Unicode 17
+`GraphemeBreakTest.txt`, `WordBreakTest.txt`, and `LineBreakTest.txt`, every
+`SpecialCasing.txt` and `CaseFolding.txt` source scalar, plus the historical
+crash inputs from issue #19 and the pirate-flag data-loss input from issue
+#22. `property` has no conformance test file to import from, so it relies
+solely on its curated named seeds (table boundaries, unassigned/private-use
+scalars, combining marks, noncharacters).
 
 After finding a failure:
 
@@ -109,7 +136,11 @@ legitimately change those measurements.
 ## Deferred work
 
 Line-break tailoring profiles, case-mapping Turkic/Lithuanian profiles and
-explicit resource limits, property scans, Script itemization, bidi,
-structured chunk plans and limits, Unicode-version-matched differential
-oracles, corpus reduction automation, artifact upload, and resource-guarded
-long scheduled campaigns remain follow-up work under issue #50.
+explicit resource limits, `EastAsianWidth` fuzzing (blocked on the
+`InternalEAW.roc` compiler-stack-overflow issue above), the remaining
+`Property.Row` properties (`BidiClass`, `JoiningType`/`JoiningGroup`,
+`IndicSyllabicCategory`/`IndicPositionalCategory`, `VerticalOrientation`,
+`Emoji`), Script itemization, bidi, structured chunk plans and limits,
+Unicode-version-matched differential oracles, corpus reduction automation,
+artifact upload, and resource-guarded long scheduled campaigns remain
+follow-up work under issue #50.

--- a/fuzz/property.roc
+++ b/fuzz/property.roc
@@ -1,0 +1,196 @@
+app [target] {
+	fuzz: platform "https://github.com/lukewilliamboswell/roc-fuzz/releases/download/0.2.1/9Qpttb6LTgcMaVsSBLsnaiS2mDUrf6Bxa6dX9Rqwviz4.tar.zst",
+	unicode: "../package/main.roc",
+}
+
+import FuzzSupport
+import fuzz.Fuzz
+import unicode.ByteRange
+import unicode.CanonicalCombiningClass
+import unicode.GeneralCategory
+import unicode.Property
+import unicode.Scalar
+import unicode.ScalarRange
+import unicode.TextRange
+
+RunShape : { byte_start : U64, byte_end : U64, scalar_start : U64, scalar_end : U64, value : Str }
+
+test : List(U32) -> Fuzz.Outcome
+test = |code_points| {
+	parts = FuzzSupport.source_parts(code_points)
+	source = Str.join_with(parts, "")
+
+	entries = Property.fold(source, [], |items, entry| items.append(entry))
+	iterated_scalars = Property.iter(source).fold([], |items, entry| items.append(Scalar.to_u32(entry.located.scalar)))
+	folded_scalars = entries.map(|entry| Scalar.to_u32(entry.located.scalar))
+	if iterated_scalars != folded_scalars {
+		crash "Property.iter disagreed with Property.fold on the decoded scalar sequence"
+	}
+
+	var $gc_values = []
+	var $ccc_values = []
+	for entry in entries {
+		gc_direct = GeneralCategory.of_scalar(entry.located.scalar)
+		gc_composite = Property.Row.general_category(entry.row)
+		if GeneralCategory.short(gc_direct) != GeneralCategory.short(gc_composite) {
+			crash "GeneralCategory direct query disagreed with the composite Property.Row view"
+		}
+
+		ccc_direct = CanonicalCombiningClass.of_scalar(entry.located.scalar)
+		ccc_composite = Property.Row.canonical_combining_class(entry.row)
+		if CanonicalCombiningClass.to_u8(ccc_direct) != CanonicalCombiningClass.to_u8(ccc_composite) {
+			crash "CanonicalCombiningClass direct query disagreed with the composite Property.Row view"
+		}
+
+		validate_general_category_aliases(gc_direct)
+		validate_canonical_combining_class_aliases(ccc_direct)
+
+		$gc_values = $gc_values.append(GeneralCategory.short(gc_direct))
+		$ccc_values = $ccc_values.append(CanonicalCombiningClass.to_u8(ccc_direct).to_str())
+	}
+
+	gc_runs = GeneralCategory.fold_runs(source, [], |runs, run| runs.append(gc_run_shape(run)))
+	if gc_runs != GeneralCategory.iter_runs(source).fold([], |runs, run| runs.append(gc_run_shape(run))) {
+		crash "GeneralCategory.fold_runs disagreed with GeneralCategory.iter_runs"
+	}
+	validate_runs(source, gc_runs, $gc_values)
+
+	ccc_runs = CanonicalCombiningClass.fold_runs(source, [], |runs, run| runs.append(ccc_run_shape(run)))
+	if ccc_runs != CanonicalCombiningClass.iter_runs(source).fold([], |runs, run| runs.append(ccc_run_shape(run))) {
+		crash "CanonicalCombiningClass.fold_runs disagreed with CanonicalCombiningClass.iter_runs"
+	}
+	validate_runs(source, ccc_runs, $ccc_values)
+
+	Fuzz.keep
+}
+
+gc_run_shape : GeneralCategory.Run -> RunShape
+gc_run_shape = |run| shape_from_range(run.range, GeneralCategory.short(run.value))
+
+ccc_run_shape : CanonicalCombiningClass.Run -> RunShape
+ccc_run_shape = |run| shape_from_range(run.range, CanonicalCombiningClass.to_u8(run.value).to_str())
+
+shape_from_range : TextRange, Str -> RunShape
+shape_from_range = |range, value| {
+	bytes = TextRange.byte_range(range)
+	scalars = TextRange.scalar_range(range)
+	{
+		byte_start: ByteRange.start(bytes),
+		byte_end: ByteRange.end(bytes),
+		scalar_start: ScalarRange.start(scalars),
+		scalar_end: ScalarRange.end(scalars),
+		value,
+	}
+}
+
+## Runs must be a lossless, scalar-aligned, contiguous partition of the
+## source; adjacent runs must never share a value (maximality); and every
+## scalar inside a run must carry that run's directly-queried value.
+validate_runs : Str, List(RunShape), List(Str) -> {}
+validate_runs = |source, runs, entry_values| {
+	if source == "" and !runs.is_empty() {
+		crash "empty source produced a property run"
+	}
+	if source != "" and runs.is_empty() {
+		crash "nonempty source produced no property runs"
+	}
+
+	var $next_byte = 0
+	var $next_scalar = 0
+	var $entry_index = 0
+	var $previous_value = None
+	for run in runs {
+		if run.byte_start != $next_byte or run.byte_end <= run.byte_start or run.scalar_start != $next_scalar or run.scalar_end <= run.scalar_start {
+			crash "property runs were empty, overlapping, or discontinuous"
+		}
+		match $previous_value {
+			None => {}
+			Some(previous) => if previous == run.value {
+				crash "adjacent property runs shared a value and were not maximal"
+			}
+		}
+		while $entry_index < run.scalar_end {
+			entry_value = entry_values.get($entry_index) ?? crash "a property run referenced a scalar beyond the decoded entries"
+			if entry_value != run.value {
+				crash "a scalar inside a property run did not match the run's directly-queried value"
+			}
+			$entry_index = $entry_index + 1
+		}
+		$next_byte = run.byte_end
+		$next_scalar = run.scalar_end
+		$previous_value = Some(run.value)
+	}
+	if $next_byte != source.count_utf8_bytes() or $next_scalar != entry_values.len() {
+		crash "property runs did not cover the complete source"
+	}
+	{}
+}
+
+validate_general_category_aliases : GeneralCategory.Value -> {}
+validate_general_category_aliases = |value| {
+	short = GeneralCategory.short(value)
+	long = GeneralCategory.long(value)
+	if GeneralCategory.short(GeneralCategory.parse(short) ?? crash "GeneralCategory.parse rejected its own short alias") != short {
+		crash "GeneralCategory short alias did not round-trip"
+	}
+	if GeneralCategory.short(GeneralCategory.parse(long) ?? crash "GeneralCategory.parse rejected its own long alias") != short {
+		crash "GeneralCategory long alias did not round-trip"
+	}
+	count = GeneralCategory.alias_count(value)
+	var $index = 0.U8
+	while $index < count {
+		alias = match GeneralCategory.alias_at(value, $index) {
+			Some(alias_text) => alias_text
+			None => crash "GeneralCategory.alias_at returned None below its own alias_count"
+		}
+		if GeneralCategory.short(GeneralCategory.parse(alias) ?? crash "GeneralCategory.parse rejected its own generated alias") != short {
+			crash "a GeneralCategory alias did not round-trip"
+		}
+		$index = $index + 1
+	}
+	{}
+}
+
+validate_canonical_combining_class_aliases : CanonicalCombiningClass -> {}
+validate_canonical_combining_class_aliases = |value| {
+	numeric = CanonicalCombiningClass.to_u8(value)
+	match CanonicalCombiningClass.short(value) {
+		None => {}
+		Some(short) => {
+			parsed = CanonicalCombiningClass.parse(short) ?? crash "CanonicalCombiningClass.parse rejected its own short alias"
+			if CanonicalCombiningClass.to_u8(parsed) != numeric {
+				crash "CanonicalCombiningClass short alias did not round-trip"
+			}
+		}
+	}
+	match CanonicalCombiningClass.long(value) {
+		None => {}
+		Some(long) => {
+			parsed = CanonicalCombiningClass.parse(long) ?? crash "CanonicalCombiningClass.parse rejected its own long alias"
+			if CanonicalCombiningClass.to_u8(parsed) != numeric {
+				crash "CanonicalCombiningClass long alias did not round-trip"
+			}
+		}
+	}
+	count = CanonicalCombiningClass.alias_count(value)
+	var $index = 0.U8
+	while $index < count {
+		alias = match CanonicalCombiningClass.alias_at(value, $index) {
+			Some(alias_text) => alias_text
+			None => crash "CanonicalCombiningClass.alias_at returned None below its own alias_count"
+		}
+		parsed = CanonicalCombiningClass.parse(alias) ?? crash "CanonicalCombiningClass.parse rejected its own generated alias"
+		if CanonicalCombiningClass.to_u8(parsed) != numeric {
+			crash "a CanonicalCombiningClass alias did not round-trip"
+		}
+		$index = $index + 1
+	}
+	{}
+}
+
+target = Fuzz.target_with({
+	name: "unicode-property",
+	generator: FuzzSupport.scalar_sequence,
+	test,
+	show: FuzzSupport.show_scalars,
+})

--- a/fuzz/seeds.json
+++ b/fuzz/seeds.json
@@ -60,5 +60,14 @@
     { "name": "kelvin-sign", "bytes_hex": "E284AA" },
     { "name": "ligature-ffi", "bytes_hex": "EFAC83" },
     { "name": "combining-dot-above", "bytes_hex": "69CC87" }
+  ],
+  "property": [
+    { "name": "ascii-boundary", "bytes_hex": "415A617A3039" },
+    { "name": "unassigned-scalar", "bytes_hex": "CDB8" },
+    { "name": "private-use-scalar", "bytes_hex": "EE8080" },
+    { "name": "combining-marks", "bytes_hex": "65CC80CCA7" },
+    { "name": "bmp-page-boundary", "bytes_hex": "C3BFC480EFBFBF" },
+    { "name": "supplementary-plane-boundary", "bytes_hex": "EFBFBFF0908080" },
+    { "name": "noncharacter", "bytes_hex": "EFB790" }
   ]
 }

--- a/scripts/fuzz.py
+++ b/scripts/fuzz.py
@@ -51,6 +51,7 @@ TARGETS = {
     "word": Target("word", FUZZ_ROOT / "word.roc", 384),
     "line-break": Target("line-break", FUZZ_ROOT / "line-break.roc", 384),
     "case": Target("case", FUZZ_ROOT / "case.roc", 384),
+    "property": Target("property", FUZZ_ROOT / "property.roc", 384),
 }
 
 
@@ -144,10 +145,11 @@ def load_seeds() -> dict[str, list[tuple[str, bytes]]]:
         "word",
         "line-break",
         "case",
+        "property",
     }:
         raise FuzzFailure(
             "fuzz seed manifest fields must be schema_version, utf8, grapheme, word, "
-            "line-break, case"
+            "line-break, case, property"
         )
     if data["schema_version"] != 1:
         raise FuzzFailure("unsupported fuzz seed manifest schema")
@@ -163,7 +165,7 @@ def load_seeds() -> dict[str, list[tuple[str, bytes]]]:
         names = [name for name, _payload in parsed]
         if len(names) != len(set(names)):
             raise FuzzFailure(f"{target_name} seed names must be unique")
-        if target_name in ("grapheme", "word", "line-break", "case"):
+        if target_name in ("grapheme", "word", "line-break", "case", "property"):
             for name, payload in parsed:
                 try:
                     payload.decode("utf-8")


### PR DESCRIPTION
## Summary

Stacked on #60 (case), #59 (line-break), #58 (word). Extends the coverage-guided fuzzing foundation (#50) with a `property` target, `fuzz/property.roc`, exercising `GeneralCategory` and `CanonicalCombiningClass` property lookups and scans over the full scalar domain — issue #50's priority 3 item.

- Checks `Property.iter` agrees with `Property.fold` on the decoded scalar sequence.
- Checks each scalar's direct query (`GeneralCategory.of_scalar`/`CanonicalCombiningClass.of_scalar`) agrees with the composite `Property.Row` view.
- Checks `fold_runs` agrees with `iter_runs`.
- Checks runs form a lossless, scalar-aligned, contiguous partition where adjacent runs never share a value (maximality) and every scalar inside a run carries that run's directly-queried value.
- Checks every short/long/generated alias round-trips through `parse` back to the same value.
- The full-range scalar generator exercises table boundaries and unassigned/private-use scalars without any special-casing needed.
- Registers `property` in `scripts/fuzz.py`'s `TARGETS` and widens the seed-manifest schema. No conformance test file exists for this domain, so it's seeded only from curated named scalars (table boundaries, unassigned, private-use, combining marks, noncharacters).
- Documents the new target in `fuzz/README.md`.

**`EastAsianWidth` is excluded** — a real compiler issue found while building this target: its generated `InternalEAW.roc` lookup is a single very large if/else boolean-OR chain (unlike the compact page-table lookups `GeneralCategory`/`CanonicalCombiningClass` use), and compiling any call into it reproducibly overflows the Roc compiler's stack. This isn't a fuzz-platform-specific quirk — it reproduces under plain `roc check`/`roc build` too. Filed upstream as [roc-lang/roc#10755](https://github.com/roc-lang/roc/issues/10755) and noted in the README's deferred-work list, alongside the other `Property.Row` properties this target doesn't yet cover (`BidiClass`, joining/indic properties, `VerticalOrientation`, `Emoji`).

## Test plan

- [x] `scripts/fuzz.py build property` — formats, type-checks, and builds cleanly.
- [x] `scripts/fuzz.py smoke property` — clean run, no crashes.
- [x] `scripts/fuzz.py smoke` (all targets) — `utf8`/`grapheme`/`word`/`line-break`/`case`/`property` all pass, confirming CI's `fuzz-smoke` job is unaffected.
- [x] `scripts/fuzz.py campaign property -- --time=1800` — 30-minute local campaign, 1,016,927 executions (~564 exec/s), no crashes found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)