### PR TITLE
Rename Grapheme.owned back to Grapheme.split

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Grapheme segmentation follows the default, un-tailored Unicode 17 extended
 grapheme cluster algorithm. Its primary output is half-open UTF-8 byte ranges;
 callers can consume them lazily with `Grapheme.iter_ranges`, collect them with
 `Grapheme.ranges`, retain seamless source slices with `Grapheme.slices`, or
-request independent copies with `Grapheme.owned`. `Grapheme.Cursor` carries the
+request independent copies with `Grapheme.split`. `Grapheme.Cursor` carries the
 same algorithm across scalar-aligned streaming chunks without treating a chunk
 edge as end-of-text.
 

--- a/examples/split-graphemes.roc
+++ b/examples/split-graphemes.roc
@@ -15,7 +15,7 @@ default_text = "🇦🇺🦘🪃"
 
 ## Return zero-copy extended grapheme cluster slices with byte coordinates.
 ## The slices retain the source backing storage, which is appropriate while
-## producing this report; use Grapheme.owned only when independent copies are
+## producing this report; use Grapheme.split only when independent copies are
 ## required. Deriving offsets from each slice avoids segmenting the text twice.
 segment : Str -> List({ end : U64, start : U64, text : Str })
 segment = |source| {

--- a/fuzz/grapheme.roc
+++ b/fuzz/grapheme.roc
@@ -32,8 +32,8 @@ test = |code_points| {
 	if Grapheme.slices(source) != expected_materialized {
 		crash "Grapheme.slices disagreed with range materialization"
 	}
-	if Grapheme.owned(source) != expected_materialized {
-		crash "Grapheme.owned disagreed with range materialization"
+	if Grapheme.split(source) != expected_materialized {
+		crash "Grapheme.split disagreed with range materialization"
 	}
 	if Str.join_with(expected_materialized, "") != source {
 		crash "grapheme materialization lost or changed source text"

--- a/package/Grapheme.roc
+++ b/package/Grapheme.roc
@@ -101,9 +101,9 @@ Grapheme :: [].{
 		)
 	}
 
-	## Return independently materialized cluster strings.
-	owned : Str -> List(Str)
-	owned = |source| {
+	## Split the source into independently materialized cluster strings.
+	split : Str -> List(Str)
+	split = |source| {
 		InternalGrapheme.ranges(source).map(
 			|range| {
 				slice = ByteRange.slice(range, source) ?? ...


### PR DESCRIPTION
Closes #55

## Summary

- rename the owned grapheme materializer from `Grapheme.owned` to `Grapheme.split`
- update README and example guidance to retain the explicit independent-copy contract
- update the grapheme fuzz parity check to exercise the renamed API

## Validation

- `ROC=/Users/luke/roc_nightly-macos_apple_silicon-2026-08-31-86e69b4/roc ./scripts/all_tests.sh`
- focused package and fuzz checks